### PR TITLE
70 box shadow not visible

### DIFF
--- a/components/layout/AppFooter.vue
+++ b/components/layout/AppFooter.vue
@@ -14,15 +14,15 @@
         <h2 class="text-sm md:text-base font-semibold mb-2">Kontakt Info</h2>
         <ul class="space-y-1">
           <li class="flex items-center">
-            <MapMarker class="w-6 h-6 text-accent-600 mr-2" aria-hidden="true" />
+            <MapMarker class="w-6 h-6 text-accent-400 mr-2" aria-hidden="true" />
             <address>Öregrundsgatan 24, 115 59 Stockholm</address>
           </li>
           <li class="flex items-center">
-            <EmailIcon class="w-6 h-6 text-accent-600 mr-2" aria-hidden="true" />
+            <EmailIcon class="w-6 h-6 text-accent-400 mr-2" aria-hidden="true" />
             <address>info@tricolorscreen.se</address>
           </li>
           <li class="flex items-center">
-            <PhoneIcon class="w-6 h-6 text-accent-600 mr-2" aria-hidden="true" />
+            <PhoneIcon class="w-6 h-6 text-accent-400 mr-2" aria-hidden="true" />
             <address>08-665 30 95</address>
           </li>
         </ul>

--- a/components/layout/AppHeader.vue
+++ b/components/layout/AppHeader.vue
@@ -20,7 +20,7 @@ const handleNavigation = async (href: string): Promise<void> => {
 </script>
 
 <template>
-  <header class="bg-neutral-900 px-5 sticky top-0 z-50 shadow-lg">
+  <header class="bg-neutral-900 px-5 sticky top-0 z-50 shadow-[0_4px_10px_rgba(0,0,0,0.25)] shadow-black/50">
     <div class="max-w-screen-xl mx-auto flex items-center justify-between min-h-[80px]">
       <!-- Logo -->
       <NuxtLink to="/" class="logo-link" @click="handleNavigation('/')">

--- a/components/layout/NavBar.vue
+++ b/components/layout/NavBar.vue
@@ -210,12 +210,6 @@ const handleNavFocus = (item: INavItem): void => {
  */
 const handleNavigation = async (href: string): Promise<void> => {
   closeDropdown()
-
-  // Remove focus from active element to prevent stuck hover states on touch devices
-  if (isTouchDevice.value && document.activeElement instanceof HTMLElement) {
-    document.activeElement.blur()
-  }
-
   await router.push(href)
 }
 

--- a/components/layout/NavBar.vue
+++ b/components/layout/NavBar.vue
@@ -354,7 +354,7 @@ watch(
 
 /* Dropdown links */
 .dropdown-link {
-  @apply block w-full px-6 py-3 text-layout-text-on-dark text-sm lg:text-base;
+  @apply block w-full px-6 py-3 text-layout-text-on-dark font-medium text-sm lg:text-base;
   @apply no-underline transition-colors duration-200 min-h-[44px];
 }
 

--- a/components/layout/NavBar.vue
+++ b/components/layout/NavBar.vue
@@ -266,8 +266,8 @@ watch(
 </script>
 
 <template>
-  <nav class="flex flex-1 justify-end" :class="{ 'is-touch-device': isTouchDevice }" aria-label="Huvudnavigering">
-    <ul class="hidden sm:flex items-center gap-0 list-none m-0 p-0">
+  <nav class="hidden sm:flex flex-1 justify-end" :class="{ 'is-touch-device': isTouchDevice }" aria-label="Huvudnavigering">
+    <ul class="flex items-center gap-0 list-none m-0 p-0">
       <li
         v-for="item in menuItems"
         :key="item.href"
@@ -308,7 +308,7 @@ watch(
         <ul
           v-if="item.children"
           class="absolute top-full left-0 min-w-[250px] bg-neutral-900 list-none m-0 py-2 transition-all duration-200 ease-in-out"
-          :class="openDropdown === item.href ? 'opacity-100 pointer-events-auto translate-y-0 shadow-lg' : 'opacity-0 pointer-events-none -translate-y-2.5 shadow-none'"
+          :class="openDropdown === item.href ? 'opacity-100 pointer-events-auto translate-y-0 shadow-[4px_4px_10px_rgba(0,0,0,0.25)] shadow-black/50' : 'opacity-0 pointer-events-none -translate-y-2.5 shadow-none'"
           :aria-label="`${item.label} undermeny`"
         >
           <li v-for="(child, index) in item.children" :key="child.href" class="dropdown-item flex">
@@ -354,8 +354,8 @@ watch(
 }
 
 .nav-link.active {
-  @apply bg-neutral-700;
-  border-bottom-color: white;
+  @apply text-accent-300;
+  border-bottom-color: theme('colors.accent.300');
 }
 
 /* Dropdown links */
@@ -374,10 +374,10 @@ watch(
 }
 
 .dropdown-link:focus-visible {
-  @apply outline-2 outline-layout-text-on-dark -outline-offset-2 bg-neutral-700;
+  @apply outline-2 outline-layout-text-on-dark -outline-offset-2;
 }
 
 .dropdown-link.active {
-  @apply bg-neutral-700 font-semibold;
+  @apply text-accent-300;
 }
 </style>

--- a/components/layout/NavBar.vue
+++ b/components/layout/NavBar.vue
@@ -348,8 +348,8 @@ watch(
 }
 
 .nav-link.active {
-  @apply text-accent-300;
-  border-bottom-color: theme('colors.accent.300');
+ @apply text-accent-400;
+  border-bottom-color: theme('colors.accent.400');
 }
 
 /* Dropdown links */
@@ -372,6 +372,6 @@ watch(
 }
 
 .dropdown-link.active {
-  @apply text-accent-300;
+  @apply text-accent-400;
 }
 </style>


### PR DESCRIPTION
## 📝 Description

- The box-shadow is visible on the header and dropdown element
- \<nav> is collapsed for mobile
- Active has yellow text and border 'CSS indicator' now

Fixes #70

## 🔍 Type of change

- [x] Bug fix

## ✅ Checklist

- [x] Code follows project coding standards
- [x] All TypeScript types are properly defined
- [ ] Components are properly documented
- [x] No console.logs in production code
- [x] Responsive design tested on all breakpoints
- [x] No ESLint errors or warnings
- [x] No security audit errors or warnings
- [x] Lighthouse performance is still ok

## 💡 Additional context
