### PR TITLE
Fixed 'Parent not deactivated after reload' problem

### DIFF
--- a/components/layout/NavBar.vue
+++ b/components/layout/NavBar.vue
@@ -274,13 +274,14 @@ onUnmounted(() => {
 
 // Sync current route with store on mount and route changes
 // Using immediate: true ensures route is set during component setup
+// flush: 'sync' ensures store is updated before rendering on iPad Safari
 watch(
   () => route.path,
   (newPath) => {
     navigationStore.setCurrentRoute(newPath)
     navigationStore.setContactLabel()
   },
-  { immediate: true }
+  { immediate: true, flush: 'sync' }
 )
 </script>
 

--- a/components/layout/NavBar.vue
+++ b/components/layout/NavBar.vue
@@ -25,6 +25,21 @@ const isTouchDevice = ref(false)
 const isBurgerOpen = ref(false)
 const navDropdownRefs = ref<Record<string, HTMLElement>>({})
 
+// ===== COMPUTED =====
+/**
+ * Create a reactive map of active states for all menu items
+ * This ensures proper reactivity on all devices including iPad Safari
+ */
+const activeStates = computed(() => {
+  const states: Record<string, boolean> = {}
+  menuItems.value.forEach((item) => {
+    states[item.href] = 
+      navigationStore.isRouteActive(item.href) ||
+      (item.children ? navigationStore.isParentActive(item.href) : false)
+  })
+  return states
+})
+
 // ===== METHODS =====
 /**
  * Toggle dropdown visibility
@@ -255,10 +270,7 @@ const handleNavClick = async (event: Event, item: INavItem): Promise<void> => {
  * Check if route or any of its children is active
  */
 const isActiveOrParent = (item: INavItem): boolean => {
-  return (
-    navigationStore.isRouteActive(item.href) ||
-    (item.children ? navigationStore.isParentActive(item.href) : false)
-  )
+  return activeStates.value[item.href] ?? false
 }
 
 // ===== LIFECYCLE =====

--- a/components/layout/NavBar.vue
+++ b/components/layout/NavBar.vue
@@ -25,21 +25,6 @@ const isTouchDevice = ref(false)
 const isBurgerOpen = ref(false)
 const navDropdownRefs = ref<Record<string, HTMLElement>>({})
 
-// ===== COMPUTED =====
-/**
- * Create a reactive map of active states for all menu items
- * This ensures proper reactivity on all devices including iPad Safari
- */
-const activeStates = computed(() => {
-  const states: Record<string, boolean> = {}
-  menuItems.value.forEach((item) => {
-    states[item.href] = 
-      navigationStore.isRouteActive(item.href) ||
-      (item.children ? navigationStore.isParentActive(item.href) : false)
-  })
-  return states
-})
-
 // ===== METHODS =====
 /**
  * Toggle dropdown visibility
@@ -270,7 +255,10 @@ const handleNavClick = async (event: Event, item: INavItem): Promise<void> => {
  * Check if route or any of its children is active
  */
 const isActiveOrParent = (item: INavItem): boolean => {
-  return activeStates.value[item.href] ?? false
+  return (
+    navigationStore.isRouteActive(item.href) ||
+    (item.children ? navigationStore.isParentActive(item.href) : false)
+  )
 }
 
 // ===== LIFECYCLE =====

--- a/components/layout/NavBar.vue
+++ b/components/layout/NavBar.vue
@@ -246,19 +246,27 @@ const handleNavClick = async (event: Event, item: INavItem): Promise<void> => {
       }
     }
   } else {
-    // Navigate for items without children
-    await handleNavigation(item.href)
+    // For items without children, just close dropdown and let NuxtLink handle navigation
+    closeDropdown()
   }
 }
 
 /**
  * Check if route or any of its children is active
+ * Uses route.path directly to ensure SSR/client hydration consistency
  */
 const isActiveOrParent = (item: INavItem): boolean => {
-  return (
-    navigationStore.isRouteActive(item.href) ||
-    (item.children ? navigationStore.isParentActive(item.href) : false)
-  )
+  // Check if current route matches this item
+  if (route.path === item.href) {
+    return true
+  }
+  
+  // Check if any children match the current route
+  if (item.children) {
+    return item.children.some(child => route.path === child.href)
+  }
+  
+  return false
 }
 
 // ===== LIFECYCLE =====
@@ -266,20 +274,27 @@ const isActiveOrParent = (item: INavItem): boolean => {
 onMounted(() => {
   isTouchDevice.value = 'ontouchstart' in window || navigator.maxTouchPoints > 0
   document.addEventListener('pointerdown', handleOutsidePointer)
+  
+  // Ensure store is in sync on mount
+  navigationStore.setCurrentRoute(route.path)
+  
+  // Use router afterEach to ensure store updates after every navigation
+  // This is more reliable than just watching route.path, especially on iOS Safari
+  router.afterEach((to) => {
+    navigationStore.setCurrentRoute(to.path)
+  })
 })
 
 onUnmounted(() => {
   document.removeEventListener('pointerdown', handleOutsidePointer)
 })
 
-// Sync current route with store on mount and route changes
-// Using immediate: true ensures route is set during component setup
+// Backup watcher for route changes (in case afterEach doesn't fire in some scenarios)
 watch(
   () => route.path,
   (newPath) => {
     navigationStore.setCurrentRoute(newPath)
-  },
-  { immediate: true }
+  }
 )
 </script>
 
@@ -314,7 +329,7 @@ watch(
           <li v-for="(child, index) in item.children" :key="child.href" class="dropdown-item flex">
             <NuxtLink
               :to="child.href" class="dropdown-link" :class="{
-                active: navigationStore.isRouteActive(child.href),
+                active: route.path === child.href,
               }" 
               @click.prevent="handleNavigation(child.href)"
               @keydown="handleDropdownItemKeydown($event, item.href, index, item.children.length)"

--- a/components/layout/NavBar.vue
+++ b/components/layout/NavBar.vue
@@ -182,7 +182,7 @@ const handleNavItemFocusOut = (event: FocusEvent): void => {
 }
 
 /**
- * Handle focus leaving the nav item (safari issue fix)
+ * Handle focus leaving the nav item (Safari issue fix)
  */
 const handleOutsidePointer = (event: PointerEvent) => {
   // Check if click/tap is inside the currently open dropdown
@@ -279,7 +279,6 @@ watch(
   () => route.path,
   (newPath) => {
     navigationStore.setCurrentRoute(newPath)
-    navigationStore.setContactLabel()
   },
   { immediate: true, flush: 'sync' }
 )

--- a/components/layout/NavBar.vue
+++ b/components/layout/NavBar.vue
@@ -266,6 +266,7 @@ const isActiveOrParent = (item: INavItem): boolean => {
 onMounted(() => {
   isTouchDevice.value = 'ontouchstart' in window || navigator.maxTouchPoints > 0
   document.addEventListener('pointerdown', handleOutsidePointer)
+  navigationStore.setCurrentRoute(route.path)
 })
 
 onUnmounted(() => {

--- a/components/layout/NavBar.vue
+++ b/components/layout/NavBar.vue
@@ -309,7 +309,7 @@ watch(
         <ul
         v-if="item.children"
           :ref="(el) => { if (el) navDropdownRefs[item.href] = el as HTMLElement }"
-          class="absolute top-full left-0 min-w-[250px] bg-neutral-900 list-none m-0 py-2 transition-all duration-200 ease-in-out"
+          class="absolute top-full left-0 min-w-[250px] max-h-[80vh] overflow-y-auto bg-neutral-900 list-none m-0 py-2 transition-all duration-200 ease-in-out"
           :class="openDropdown === item.href ? 'opacity-100 pointer-events-auto translate-y-0 shadow-[4px_4px_10px_rgba(0,0,0,0.25)] shadow-black/50' : 'opacity-0 pointer-events-none -translate-y-2.5 shadow-none'"
           :aria-label="`${item.label} undermeny`">
           <li v-for="(child, index) in item.children" :key="child.href" class="dropdown-item flex">

--- a/components/layout/NavBar.vue
+++ b/components/layout/NavBar.vue
@@ -266,7 +266,6 @@ const isActiveOrParent = (item: INavItem): boolean => {
 onMounted(() => {
   isTouchDevice.value = 'ontouchstart' in window || navigator.maxTouchPoints > 0
   document.addEventListener('pointerdown', handleOutsidePointer)
-  navigationStore.setCurrentRoute(route.path)
 })
 
 onUnmounted(() => {
@@ -274,6 +273,7 @@ onUnmounted(() => {
 })
 
 // Sync current route with store on mount and route changes
+// Using immediate: true ensures route is set during component setup
 watch(
   () => route.path,
   (newPath) => {

--- a/components/layout/NavBar.vue
+++ b/components/layout/NavBar.vue
@@ -278,6 +278,7 @@ watch(
   () => route.path,
   (newPath) => {
     navigationStore.setCurrentRoute(newPath)
+    navigationStore.setContactLabel()
   },
   { immediate: true }
 )

--- a/components/layout/NavBar.vue
+++ b/components/layout/NavBar.vue
@@ -246,27 +246,19 @@ const handleNavClick = async (event: Event, item: INavItem): Promise<void> => {
       }
     }
   } else {
-    // For items without children, just close dropdown and let NuxtLink handle navigation
-    closeDropdown()
+    // Navigate for items without children
+    await handleNavigation(item.href)
   }
 }
 
 /**
  * Check if route or any of its children is active
- * Uses route.path directly to ensure SSR/client hydration consistency
  */
 const isActiveOrParent = (item: INavItem): boolean => {
-  // Check if current route matches this item
-  if (route.path === item.href) {
-    return true
-  }
-  
-  // Check if any children match the current route
-  if (item.children) {
-    return item.children.some(child => route.path === child.href)
-  }
-  
-  return false
+  return (
+    navigationStore.isRouteActive(item.href) ||
+    (item.children ? navigationStore.isParentActive(item.href) : false)
+  )
 }
 
 // ===== LIFECYCLE =====
@@ -274,27 +266,20 @@ const isActiveOrParent = (item: INavItem): boolean => {
 onMounted(() => {
   isTouchDevice.value = 'ontouchstart' in window || navigator.maxTouchPoints > 0
   document.addEventListener('pointerdown', handleOutsidePointer)
-  
-  // Ensure store is in sync on mount
-  navigationStore.setCurrentRoute(route.path)
-  
-  // Use router afterEach to ensure store updates after every navigation
-  // This is more reliable than just watching route.path, especially on iOS Safari
-  router.afterEach((to) => {
-    navigationStore.setCurrentRoute(to.path)
-  })
 })
 
 onUnmounted(() => {
   document.removeEventListener('pointerdown', handleOutsidePointer)
 })
 
-// Backup watcher for route changes (in case afterEach doesn't fire in some scenarios)
+// Sync current route with store on mount and route changes
+// Using immediate: true ensures route is set during component setup
 watch(
   () => route.path,
   (newPath) => {
     navigationStore.setCurrentRoute(newPath)
-  }
+  },
+  { immediate: true }
 )
 </script>
 
@@ -329,7 +314,7 @@ watch(
           <li v-for="(child, index) in item.children" :key="child.href" class="dropdown-item flex">
             <NuxtLink
               :to="child.href" class="dropdown-link" :class="{
-                active: route.path === child.href,
+                active: navigationStore.isRouteActive(child.href),
               }" 
               @click.prevent="handleNavigation(child.href)"
               @keydown="handleDropdownItemKeydown($event, item.href, index, item.children.length)"

--- a/components/layout/NavBar.vue
+++ b/components/layout/NavBar.vue
@@ -83,7 +83,7 @@ const handleDropdownKeydown = (event: KeyboardEvent, item: INavItem): void => {
  */
 const handleDropdownItemKeydown = (
   event: KeyboardEvent,
-  parentHref: string,
+  _parentHref: string,
   childIndex: number,
   totalChildren: number
 ): void => {

--- a/components/layout/NavBar.vue
+++ b/components/layout/NavBar.vue
@@ -23,6 +23,7 @@ const route = useRoute()
 const openDropdown = ref<string | null>(null)
 const isTouchDevice = ref(false)
 const isBurgerOpen = ref(false)
+const navDropdownRefs = ref<Record<string, HTMLElement>>({})
 
 // ===== METHODS =====
 /**
@@ -175,7 +176,21 @@ const handleNavItemFocusOut = (event: FocusEvent): void => {
   const relatedTarget = event.relatedTarget as HTMLElement
 
   // Check if the new focus target is still within this nav item
-  if (!navItem.contains(relatedTarget)) {
+  if (!relatedTarget || !navItem.contains(relatedTarget)) {
+    closeDropdown()
+  }
+}
+
+/**
+ * Handle focus leaving the nav item (safari issue fix)
+ */
+const handleOutsidePointer = (event: PointerEvent) => {
+  // Check if click/tap is inside the currently open dropdown
+  const openHref = openDropdown.value
+  if (!openHref) return
+
+  const dropdownEl = navDropdownRefs.value[openHref]
+  if (!dropdownEl?.contains(event.target as Node)) {
     closeDropdown()
   }
 }
@@ -250,6 +265,11 @@ const isActiveOrParent = (item: INavItem): boolean => {
 // Detect touch device on mount
 onMounted(() => {
   isTouchDevice.value = 'ontouchstart' in window || navigator.maxTouchPoints > 0
+  document.addEventListener('pointerdown', handleOutsidePointer)
+})
+
+onUnmounted(() => {
+  document.removeEventListener('pointerdown', handleOutsidePointer)
 })
 
 // Sync current route with store on mount and route changes
@@ -286,14 +306,16 @@ watch(
         <!-- Dropdown menu for children -->
         <ul
         v-if="item.children"
+          ref="el => { if (el) navDropdownRefs.value[item.href] = el }"
           class="absolute top-full left-0 min-w-[250px] bg-neutral-900 list-none m-0 py-2 transition-all duration-200 ease-in-out"
           :class="openDropdown === item.href ? 'opacity-100 pointer-events-auto translate-y-0 shadow-[4px_4px_10px_rgba(0,0,0,0.25)] shadow-black/50' : 'opacity-0 pointer-events-none -translate-y-2.5 shadow-none'"
           :aria-label="`${item.label} undermeny`">
           <li v-for="(child, index) in item.children" :key="child.href" class="dropdown-item flex">
             <NuxtLink
-            :to="child.href" class="dropdown-link" :class="{
-              active: navigationStore.isRouteActive(child.href),
-            }" @click.prevent="handleNavigation(child.href)"
+              :to="child.href" class="dropdown-link" :class="{
+                active: navigationStore.isRouteActive(child.href),
+              }" 
+              @click.prevent="handleNavigation(child.href)"
               @keydown="handleDropdownItemKeydown($event, item.href, index, item.children.length)"
               @focus="openDropdownMenu(item.href)">
               {{ child.label }}

--- a/components/layout/NavBar.vue
+++ b/components/layout/NavBar.vue
@@ -306,7 +306,7 @@ watch(
         <!-- Dropdown menu for children -->
         <ul
         v-if="item.children"
-          ref="el => { if (el) navDropdownRefs.value[item.href] = el }"
+          :ref="(el) => { if (el) navDropdownRefs[item.href] = el as HTMLElement }"
           class="absolute top-full left-0 min-w-[250px] bg-neutral-900 list-none m-0 py-2 transition-all duration-200 ease-in-out"
           :class="openDropdown === item.href ? 'opacity-100 pointer-events-auto translate-y-0 shadow-[4px_4px_10px_rgba(0,0,0,0.25)] shadow-black/50' : 'opacity-0 pointer-events-none -translate-y-2.5 shadow-none'"
           :aria-label="`${item.label} undermeny`">

--- a/stores/navigationStore.ts
+++ b/stores/navigationStore.ts
@@ -123,11 +123,13 @@ export const useNavigationStore = defineStore('navigation', {
     setContactLabel(): void {
       // const lastRoutePart = this.currentRoute.split("/").filter(Boolean).pop()?.toUpperCase() ?? "/";
       const contactItem = this.menuItems.find(item => item.href === '/contact');
+      const parentItem = this.menuItems.find(item => item.href === '/services');
 
 
-      if(contactItem ) {
-        const isActiveParent = this.isParentActive('/services');
-        contactItem.label = isActiveParent ? 'TRUE' : 'FALSE';
+      if(contactItem && parentItem) {
+        // const isActiveParent = this.isParentActive('/services');
+        // contactItem.label = isActiveParent ? 'TRUE' : 'FALSE';
+        contactItem.label = parentItem.children?.[0]?.href ?? 'null'
       }
     },
 

--- a/stores/navigationStore.ts
+++ b/stores/navigationStore.ts
@@ -101,16 +101,14 @@ export const useNavigationStore = defineStore('navigation', {
     /**
      * Check if current route matches any child route of a menu item
      */
-    isParentActive: state => {
+    isParentActive(): (parentHref: string) => boolean {
       return (parentHref: string): boolean => {
-        const parent = state.menuItems.find(item => item.href === parentHref)
-        if (!parent?.children) {
-          return false
-        } else {
-          return parent.children.some(
-            child => child.href === state.currentRoute
-          )
-        }
+        const parent = this.menuItems.find(item => item.href === parentHref)
+        if (!parent?.children) return false
+
+        return parent.children.some(
+          child => child.href === this.currentRoute
+        )
       }
     },
 

--- a/stores/navigationStore.ts
+++ b/stores/navigationStore.ts
@@ -87,7 +87,7 @@ export const useNavigationStore = defineStore('navigation', {
     /**
      * Check if current route matches any child route of a menu item
      */
-    isParent: state => {
+    hasChildren: state => {
       return (parentHref: string): boolean => {
         const parent = state.menuItems.find(item => item.href === parentHref)
         if (!parent?.children) {
@@ -143,9 +143,9 @@ export const useNavigationStore = defineStore('navigation', {
 
 
       if(contactItem && parentItem) {
-        const isParent = this.isParent('/services') ? 'TRUE' : 'FALSE';
+        const hasChildren = this.hasChildren('/services') ? 'TRUE' : 'FALSE';
         const isParentActive = this.isParentActive('/services') ? 'TRUE' : 'FALSE';
-        contactItem.label = `${isParent}:${isParentActive}`;
+        contactItem.label = `${hasChildren}:${isParentActive}:${this.currentRoute}`;
         // contactItem.label = parentItem.children?.[0]?.href ?? 'null'
         // contactItem.label = this.currentRoute;
       }

--- a/stores/navigationStore.ts
+++ b/stores/navigationStore.ts
@@ -121,13 +121,18 @@ export const useNavigationStore = defineStore('navigation', {
      * Set menu items with computed contact label based on current route
      */
     setContactLabel(): void {
-      const lastRoutePart = this.currentRoute.split("/").filter(Boolean).pop()?.toUpperCase() ?? "/";
+      // const lastRoutePart = this.currentRoute.split("/").filter(Boolean).pop()?.toUpperCase() ?? "/";
+      const contactItem = this.menuItems.find(item => item.href === '/contact');
+      const servicesItem = this.menuItems.find(item => item.href === '/services/printed-matter');
       
-      this.menuItems.forEach(item => {
-        if (item.href === '/contact') {
-          item.label = lastRoutePart;
+      if(contactItem ) {
+        if(servicesItem) {
+          const isActiveParent = this.isParentActive(servicesItem.href);
+          contactItem.label = isActiveParent ? 'TRUE' : 'FALSE';
+        } else {
+          contactItem.label = 'NOT FOUND';
         }
-      });
+      }
     },
 
     /**

--- a/stores/navigationStore.ts
+++ b/stores/navigationStore.ts
@@ -129,7 +129,8 @@ export const useNavigationStore = defineStore('navigation', {
       if(contactItem && parentItem) {
         // const isActiveParent = this.isParentActive('/services');
         // contactItem.label = isActiveParent ? 'TRUE' : 'FALSE';
-        contactItem.label = parentItem.children?.[0]?.href ?? 'null'
+        // contactItem.label = parentItem.children?.[0]?.href ?? 'null'
+        contactItem.label = this.currentRoute;
       }
     },
 

--- a/stores/navigationStore.ts
+++ b/stores/navigationStore.ts
@@ -28,7 +28,7 @@ export const useNavigationStore = defineStore('navigation', {
       { label: 'HEM', href: '/' },
       {
         label: 'VÅRA TJÄNSTER',
-        href: '/services/printed-matter',
+        href: '/services',
         children: [
           { label: 'TRYCKSAKER', href: '/services/printed-matter' },
           {
@@ -123,15 +123,11 @@ export const useNavigationStore = defineStore('navigation', {
     setContactLabel(): void {
       // const lastRoutePart = this.currentRoute.split("/").filter(Boolean).pop()?.toUpperCase() ?? "/";
       const contactItem = this.menuItems.find(item => item.href === '/contact');
-      const servicesItem = this.menuItems.find(item => item.href === '/services/printed-matter');
-      
+
+
       if(contactItem ) {
-        if(servicesItem) {
-          const isActiveParent = this.isParentActive(servicesItem.href);
-          contactItem.label = isActiveParent ? 'TRUE' : 'FALSE';
-        } else {
-          contactItem.label = 'NOT FOUND';
-        }
+        const isActiveParent = this.isParentActive('/services');
+        contactItem.label = isActiveParent ? 'TRUE' : 'FALSE';
       }
     },
 

--- a/stores/navigationStore.ts
+++ b/stores/navigationStore.ts
@@ -143,7 +143,7 @@ export const useNavigationStore = defineStore('navigation', {
       if(contactItem && parentItem) {
         const hasChildren = this.hasChildren('/services') ? 'TRUE' : 'FALSE';
         const isParentActive = this.isParentActive('/services') ? 'TRUE' : 'FALSE';
-        contactItem.label = `${hasChildren}:${isParentActive}:${this.currentRoute}`;
+        contactItem.label = `${hasChildren}:${isParentActive}:${this.currentRoute}:${parentItem.children?.[0]?.href ?? 'null'} `;
         // contactItem.label = parentItem.children?.[0]?.href ?? 'null'
         // contactItem.label = this.currentRoute;
       }

--- a/stores/navigationStore.ts
+++ b/stores/navigationStore.ts
@@ -143,8 +143,9 @@ export const useNavigationStore = defineStore('navigation', {
 
 
       if(contactItem && parentItem) {
-        const isActiveParent = this.isParent('/services');
-        contactItem.label = isActiveParent ? 'TRUE' : 'FALSE';
+        const isParent = this.isParent('/services') ? 'TRUE' : 'FALSE';
+        const isParentActive = this.isParentActive('/services') ? 'TRUE' : 'FALSE';
+        contactItem.label = `${isParent}:${isParentActive}`;
         // contactItem.label = parentItem.children?.[0]?.href ?? 'null'
         // contactItem.label = this.currentRoute;
       }

--- a/stores/navigationStore.ts
+++ b/stores/navigationStore.ts
@@ -85,20 +85,6 @@ export const useNavigationStore = defineStore('navigation', {
     },
 
     /**
-     * Check if current route has children menu items
-     */
-    hasChildren: state => {
-      return (parentHref: string): boolean => {
-        const parent = state.menuItems.find(item => item.href === parentHref)
-        if (!parent?.children) {
-          return false
-        } else {
-          return true;
-        }
-      }
-    },
-
-    /**
      * Check if current route matches any child route of a menu item
      */
     isParentActive(): (parentHref: string) => boolean {
@@ -126,24 +112,6 @@ export const useNavigationStore = defineStore('navigation', {
 
   // ===== ACTIONS =====
   actions: {
-    /**
-     * Set menu items with computed contact label based on current route
-     */
-    setContactLabel(): void {
-      // const lastRoutePart = this.currentRoute.split("/").filter(Boolean).pop()?.toUpperCase() ?? "/";
-      const contactItem = this.menuItems.find(item => item.href === '/contact');
-      const parentItem = this.menuItems.find(item => item.href === '/services');
-
-
-      if(contactItem && parentItem) {
-        const hasChildren = this.hasChildren('/services') ? 'TRUE' : 'FALSE';
-        const isParentActive = this.isParentActive('/services') ? 'TRUE' : 'FALSE';
-        contactItem.label = `${hasChildren}:${isParentActive}:${this.currentRoute}:${parentItem.children?.[0]?.href ?? 'null'} `;
-        // contactItem.label = parentItem.children?.[0]?.href ?? 'null'
-        // contactItem.label = this.currentRoute;
-      }
-    },
-
     /**
      * Toggle mobile menu open/closed state
      * Manages body scroll lock to prevent background scrolling

--- a/stores/navigationStore.ts
+++ b/stores/navigationStore.ts
@@ -118,6 +118,19 @@ export const useNavigationStore = defineStore('navigation', {
   // ===== ACTIONS =====
   actions: {
     /**
+     * Set menu items with computed contact label based on current route
+     */
+    setContactLabel(): void {
+      const lastRoutePart = this.currentRoute.split("/").filter(Boolean).pop()?.toUpperCase() ?? "/";
+      
+      this.menuItems.forEach(item => {
+        if (item.href === '/contact') {
+          item.label = lastRoutePart;
+        }
+      });
+    },
+
+    /**
      * Toggle mobile menu open/closed state
      * Manages body scroll lock to prevent background scrolling
      */

--- a/stores/navigationStore.ts
+++ b/stores/navigationStore.ts
@@ -87,14 +87,30 @@ export const useNavigationStore = defineStore('navigation', {
     /**
      * Check if current route matches any child route of a menu item
      */
+    isParent: state => {
+      return (parentHref: string): boolean => {
+        const parent = state.menuItems.find(item => item.href === parentHref)
+        if (!parent?.children) {
+          return false
+        } else {
+          return true;
+        }
+      }
+    },
+
+    /**
+     * Check if current route matches any child route of a menu item
+     */
     isParentActive: state => {
       return (parentHref: string): boolean => {
         const parent = state.menuItems.find(item => item.href === parentHref)
-        if (!parent?.children) return false
-
-        return parent.children.some(
-          child => child.href === state.currentRoute
-        )
+        if (!parent?.children) {
+          return false
+        } else {
+          return parent.children.some(
+            child => child.href === state.currentRoute
+          )
+        }
       }
     },
 
@@ -127,10 +143,10 @@ export const useNavigationStore = defineStore('navigation', {
 
 
       if(contactItem && parentItem) {
-        // const isActiveParent = this.isParentActive('/services');
-        // contactItem.label = isActiveParent ? 'TRUE' : 'FALSE';
+        const isActiveParent = this.isParent('/services');
+        contactItem.label = isActiveParent ? 'TRUE' : 'FALSE';
         // contactItem.label = parentItem.children?.[0]?.href ?? 'null'
-        contactItem.label = this.currentRoute;
+        // contactItem.label = this.currentRoute;
       }
     },
 

--- a/stores/navigationStore.ts
+++ b/stores/navigationStore.ts
@@ -85,7 +85,7 @@ export const useNavigationStore = defineStore('navigation', {
     },
 
     /**
-     * Check if current route matches any child route of a menu item
+     * Check if current route has children menu items
      */
     hasChildren: state => {
       return (parentHref: string): boolean => {
@@ -103,12 +103,7 @@ export const useNavigationStore = defineStore('navigation', {
      */
     isParentActive(): (parentHref: string) => boolean {
       return (parentHref: string): boolean => {
-        const parent = this.menuItems.find(item => item.href === parentHref)
-        if (!parent?.children) return false
-
-        return parent.children.some(
-          child => child.href === this.currentRoute
-        )
+        return this.currentRoute.startsWith(parentHref + '/')
       }
     },
 


### PR DESCRIPTION
## 📝 Description

- Fixed "dropdown is not closed when it loses focus" problem

The following bugs only occurs on a real iPad mini device with Safari:

- Fixed "parent not deactivated after reload" problem

Fixes #75

## 🔍 Type of change

- [x] Bug fix

## ✅ Checklist

- [x] Code follows project coding standards
- [x] All TypeScript types are properly defined
- [ ] Components are properly documented
- [x] No console.logs in production code
- [x] Responsive design tested on all breakpoints
- [x] No ESLint errors or warnings
- [x] No security audit errors or warnings
- [x] Lighthouse performance is still ok

## 💡 Additional context
