### PR TITLE
Create a useCanvasExport composable

### DIFF
--- a/composables/useCanvasExport.ts
+++ b/composables/useCanvasExport.ts
@@ -1,0 +1,48 @@
+// composables/useCanvasExport.ts
+import type { Canvas } from 'fabric'
+import { FabricImage } from 'fabric'
+
+export function useCanvasExport() {
+  async function exportMergedImage(canvas: Canvas): Promise<string> {
+    const htmlCanvas = canvas.getElement() as HTMLCanvasElement
+
+    if (typeof htmlCanvas.toBlob === 'function') {
+      return new Promise((resolve, reject) => {
+        htmlCanvas.toBlob((blob) => {
+          if (!blob) return reject(new Error('toBlob returned null'))
+          resolve(URL.createObjectURL(blob))
+        }, 'image/png')
+      })
+    }
+
+    return canvas.toDataURL({ format: 'png', multiplier: 1 })
+  }
+
+  async function exportImageObjects(canvas: Canvas): Promise<string[]> {
+    const imageObjects = canvas
+      .getObjects()
+      .filter(obj => obj instanceof FabricImage) as FabricImage[]
+
+    return Promise.all(
+      imageObjects.map(obj => {
+        const objCanvas = obj.toCanvasElement()
+
+        if (typeof objCanvas.toBlob === 'function') {
+          return new Promise<string>((resolve, reject) => {
+            objCanvas.toBlob((blob) => {
+              if (!blob) return reject(new Error('toBlob returned null'))
+              resolve(URL.createObjectURL(blob))
+            }, 'image/png')
+          })
+        }
+
+        return Promise.resolve(objCanvas.toDataURL('image/png'))
+      })
+    )
+  }
+
+  return {
+    exportMergedImage,
+    exportImageObjects,
+  }
+}

--- a/composables/useCanvasExport.ts
+++ b/composables/useCanvasExport.ts
@@ -5,6 +5,9 @@ import { FabricImage } from 'fabric'
 export function useCanvasExport() {
   async function exportMergedImage(canvas: Canvas): Promise<string> {
     const htmlCanvas = canvas.getElement() as HTMLCanvasElement
+    
+    canvas.discardActiveObject()
+    canvas.renderAll() // Ensure canvas is fully rendered before export
 
     if (typeof htmlCanvas.toBlob === 'function') {
       return new Promise((resolve, reject) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@pinia/nuxt": "^0.11.3",
         "embla-carousel-vue": "^8.6.0",
         "fabric": "^7.1.0",
+        "nanoid": "^5.1.6",
         "nuxt": "^3.20.2",
         "pinia": "^3.0.4",
         "pinia-plugin-persistedstate": "^4.7.1",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "postinstall": "nuxi prepare",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "audit": "audit-ci --fail-level high --allowlist GHSA-2g4f-4pwh-qvx6",
-    "security:audit": "audit-ci --fail-level high --allowlist GHSA-2g4f-4pwh-qvx6"
+    "audit": "audit-ci --fail-level moderate --allowlist GHSA-2g4f-4pwh-qvx6",
+    "security:audit": "audit-ci --fail-level moderate --allowlist GHSA-2g4f-4pwh-qvx6"
   },
   "dependencies": {
     "@nuxt/eslint": "^1.12.1",
@@ -20,6 +20,7 @@
     "@pinia/nuxt": "^0.11.3",
     "embla-carousel-vue": "^8.6.0",
     "fabric": "^7.1.0",
+    "nanoid": "^5.1.6",
     "nuxt": "^3.20.2",
     "pinia": "^3.0.4",
     "pinia-plugin-persistedstate": "^4.7.1",

--- a/pages/custom-design.vue
+++ b/pages/custom-design.vue
@@ -224,74 +224,69 @@ function downloadFile(dataURL: string, filename: string): void {
     link.click()
 }
 
-function downloadCanvasMerged(id: string): void {
-  if (!canvas.value) {
-    alert('Canvas is not ready')
-    return
+async function exportCanvasMergedImage(): Promise<string> {
+  if (!canvas.value) throw new Error('Canvas is not ready')
+
+  const htmlCanvas = canvas.value.getElement() as HTMLCanvasElement
+
+  // Prefer native toBlob — avoids base64 overhead, supported in Safari 11+
+  if (typeof htmlCanvas.toBlob === 'function') {
+    return new Promise((resolve, reject) => {
+      htmlCanvas.toBlob((blob) => {
+        if (!blob) { reject(new Error('toBlob returned null')); return }
+        resolve(URL.createObjectURL(blob))
+      }, 'image/png')
+    })
   }
 
-  try {
-    const filename = `design-${id}.png`
-    const htmlCanvas = canvas.value.getElement() as HTMLCanvasElement
+  // Fallback for older browsers: dataURL
+  return canvas.value.toDataURL({ format: 'png', multiplier: 1 })
+}
 
-    // Prefer native toBlob — avoids base64 overhead, supported in Safari 11+
-    if (typeof htmlCanvas.toBlob === 'function') {
-      htmlCanvas.toBlob((blob) => {
-        if (!blob) return
-        const url = URL.createObjectURL(blob)
-        downloadFile(url, filename)
-        URL.revokeObjectURL(url)
-      }, 'image/png')
-      return
+async function exportCanvasImageObjects(): Promise<string[]> {
+  if (!canvas.value) throw new Error('Canvas is not ready')
+
+  const imageObjects = canvas.value.getObjects().filter(obj => obj instanceof FabricImage)
+
+  return Promise.all(imageObjects.map((obj) => {
+    const objCanvas = obj.toCanvasElement()
+
+    if (typeof objCanvas.toBlob === 'function') {
+      return new Promise<string>((resolve, reject) => {
+        objCanvas.toBlob((blob) => {
+          if (!blob) { reject(new Error('toBlob returned null')); return }
+          resolve(URL.createObjectURL(blob))
+        }, 'image/png')
+      })
     }
 
-    // Fallback for older browsers: dataURL
-    const dataURL = canvas.value.toDataURL({ format: 'png', multiplier: 1 })
-    downloadFile(dataURL, filename)
+    // Fallback for older browsers
+    return Promise.resolve(objCanvas.toDataURL('image/png'))
+  }))
+}
+
+async function downloadCanvasImages(): Promise<void> {
+  try {
+    const id = nanoid(10)
+    const [mergedUrl, imageUrls] = await Promise.all([
+      exportCanvasMergedImage(),
+      exportCanvasImageObjects(),
+    ])
+
+    downloadFile(mergedUrl, `design-${id}.png`)
+    URL.revokeObjectURL(mergedUrl)
+
+    // Stagger image downloads slightly so browsers don't block them
+    imageUrls.forEach((url, index) => {
+      setTimeout(() => {
+        downloadFile(url, `design-${id}-image-${index + 1}.png`)
+        URL.revokeObjectURL(url)
+      }, (index + 1) * 200)
+    })
   } catch (error) {
     alert('Failed to download design')
     console.error('Error downloading canvas:', error)
   }
-}
-
-function downloadCanvasImagesIndividually(id: string): void {
-  if (!canvas.value) return
-
-  try {
-    let imageIndex = 1
-    canvas.value.getObjects().forEach((obj, index) => {
-      if (!(obj instanceof FabricImage)) return
-
-      const objCanvas = obj.toCanvasElement()
-      const filename = `design-${id}-image-${imageIndex++}.png`
-
-      // Stagger downloads slightly so browsers don't block them
-      setTimeout(() => {
-        if (typeof objCanvas.toBlob === 'function') {
-          objCanvas.toBlob((blob) => {
-            if (!blob) return
-            const url = URL.createObjectURL(blob)
-            downloadFile(url, filename)
-            URL.revokeObjectURL(url)
-          }, 'image/png')
-          return
-        }
-
-        // Fallback for older browsers
-        const dataURL = objCanvas.toDataURL('image/png')
-        downloadFile(dataURL, filename)
-      }, index * 200)
-    })
-  } catch (error) {
-    alert('Failed to download images')
-    console.error('Error downloading canvas images:', error)
-  }
-}
-
-function downloadCanvasImages(): void {
-  const id = nanoid(10)
-  downloadCanvasMerged(id)
-  downloadCanvasImagesIndividually(id)
 }
 
 </script>

--- a/pages/custom-design.vue
+++ b/pages/custom-design.vue
@@ -3,14 +3,16 @@
 <script setup lang="ts">
 // ===== IMPORTS =====
 import { Canvas, FabricImage, ActiveSelection, Control, controlsUtils } from 'fabric'
+import { nanoid } from 'nanoid'
 import HeroImage from '~/components/common/HeroImage.vue'
 import Section from '~/components/common/Section.vue'
 import IconButton from '~/components/common/IconButton.vue'
 import ImageIcon from '~/assets/images/custom-design/image-icon.svg?component'
 import TextIcon from '~/assets/images/custom-design/text-icon.svg?component'
+import TextButton from '~/components/common/TextButton.vue'
 import { useCustomImage } from '~/composables/useCustomImage'
 import { useCustomText } from '~/composables/useCustomText'
-import { ref, shallowRef, onMounted } from 'vue'
+import { ref, shallowRef, onMounted, onBeforeUnmount } from 'vue'
 import TextboxControls from '~/components/features/TextboxControls.vue'
 import {
   createRotateControlRender,
@@ -215,6 +217,83 @@ function addText() {
   addTextToCanvas(canvas.value)
 }
 
+function downloadFile(dataURL: string, filename: string): void {
+    const link = document.createElement('a')
+    link.href = dataURL
+    link.download = filename
+    link.click()
+}
+
+function downloadCanvasMerged(id: string): void {
+  if (!canvas.value) {
+    alert('Canvas is not ready')
+    return
+  }
+
+  try {
+    const filename = `design-${id}.png`
+    const htmlCanvas = canvas.value.getElement() as HTMLCanvasElement
+
+    // Prefer native toBlob — avoids base64 overhead, supported in Safari 11+
+    if (typeof htmlCanvas.toBlob === 'function') {
+      htmlCanvas.toBlob((blob) => {
+        if (!blob) return
+        const url = URL.createObjectURL(blob)
+        downloadFile(url, filename)
+        URL.revokeObjectURL(url)
+      }, 'image/png')
+      return
+    }
+
+    // Fallback for older browsers: dataURL
+    const dataURL = canvas.value.toDataURL({ format: 'png', multiplier: 1 })
+    downloadFile(dataURL, filename)
+  } catch (error) {
+    alert('Failed to download design')
+    console.error('Error downloading canvas:', error)
+  }
+}
+
+function downloadCanvasImagesIndividually(id: string): void {
+  if (!canvas.value) return
+
+  try {
+    let imageIndex = 1
+    canvas.value.getObjects().forEach((obj, index) => {
+      if (!(obj instanceof FabricImage)) return
+
+      const objCanvas = obj.toCanvasElement()
+      const filename = `design-${id}-image-${imageIndex++}.png`
+
+      // Stagger downloads slightly so browsers don't block them
+      setTimeout(() => {
+        if (typeof objCanvas.toBlob === 'function') {
+          objCanvas.toBlob((blob) => {
+            if (!blob) return
+            const url = URL.createObjectURL(blob)
+            downloadFile(url, filename)
+            URL.revokeObjectURL(url)
+          }, 'image/png')
+          return
+        }
+
+        // Fallback for older browsers
+        const dataURL = objCanvas.toDataURL('image/png')
+        downloadFile(dataURL, filename)
+      }, index * 200)
+    })
+  } catch (error) {
+    alert('Failed to download images')
+    console.error('Error downloading canvas images:', error)
+  }
+}
+
+function downloadCanvasImages(): void {
+  const id = nanoid(10)
+  downloadCanvasMerged(id)
+  downloadCanvasImagesIndividually(id)
+}
+
 </script>
 
 <template>
@@ -274,6 +353,9 @@ function addText() {
           </div>
         </div>
         <TextboxControls :canvas="canvas" />
+        <div class="mt-24 flex justify-center gap-4">
+          <TextButton @click="downloadCanvasImages">Begär Offert</TextButton>
+        </div>
       </Section>
     </div>
   </div>

--- a/pages/custom-design.vue
+++ b/pages/custom-design.vue
@@ -12,6 +12,7 @@ import TextIcon from '~/assets/images/custom-design/text-icon.svg?component'
 import TextButton from '~/components/common/TextButton.vue'
 import { useCustomImage } from '~/composables/useCustomImage'
 import { useCustomText } from '~/composables/useCustomText'
+import { useCanvasExport } from '~/composables/useCanvasExport'
 import { ref, shallowRef, onMounted, onBeforeUnmount } from 'vue'
 import TextboxControls from '~/components/features/TextboxControls.vue'
 import {
@@ -53,6 +54,7 @@ useHead({
 
 const { addImageToCanvas } = useCustomImage()
 const { addTextToCanvas } = useCustomText()
+const { exportMergedImage, exportImageObjects } = useCanvasExport()
 
 // ===== STATE =====
 const fileInputRef = ref<HTMLInputElement | null>(null)
@@ -224,67 +226,34 @@ function downloadFile(dataURL: string, filename: string): void {
     link.click()
 }
 
-async function exportCanvasMergedImage(): Promise<string> {
-  if (!canvas.value) throw new Error('Canvas is not ready')
-
-  const htmlCanvas = canvas.value.getElement() as HTMLCanvasElement
-
-  // Prefer native toBlob — avoids base64 overhead, supported in Safari 11+
-  if (typeof htmlCanvas.toBlob === 'function') {
-    return new Promise((resolve, reject) => {
-      htmlCanvas.toBlob((blob) => {
-        if (!blob) { reject(new Error('toBlob returned null')); return }
-        resolve(URL.createObjectURL(blob))
-      }, 'image/png')
-    })
+async function downloadCanvasImages(): Promise<void> {
+  if (!canvas.value) {
+    alert('Canvas not initialized')
+    console.error('Error downloading canvas: Canvas is not initialized')
+    return
   }
 
-  // Fallback for older browsers: dataURL
-  return canvas.value.toDataURL({ format: 'png', multiplier: 1 })
-}
-
-async function exportCanvasImageObjects(): Promise<string[]> {
-  if (!canvas.value) throw new Error('Canvas is not ready')
-
-  const imageObjects = canvas.value.getObjects().filter(obj => obj instanceof FabricImage)
-
-  return Promise.all(imageObjects.map((obj) => {
-    const objCanvas = obj.toCanvasElement()
-
-    if (typeof objCanvas.toBlob === 'function') {
-      return new Promise<string>((resolve, reject) => {
-        objCanvas.toBlob((blob) => {
-          if (!blob) { reject(new Error('toBlob returned null')); return }
-          resolve(URL.createObjectURL(blob))
-        }, 'image/png')
-      })
-    }
-
-    // Fallback for older browsers
-    return Promise.resolve(objCanvas.toDataURL('image/png'))
-  }))
-}
-
-async function downloadCanvasImages(): Promise<void> {
   try {
     const id = nanoid(10)
     const [mergedUrl, imageUrls] = await Promise.all([
-      exportCanvasMergedImage(),
-      exportCanvasImageObjects(),
+      exportMergedImage(canvas.value),
+      exportImageObjects(canvas.value),
     ])
 
+    // Download merged image first
     downloadFile(mergedUrl, `design-${id}.png`)
     URL.revokeObjectURL(mergedUrl)
 
-    // Stagger image downloads slightly so browsers don't block them
+    // Download individual layer images
     imageUrls.forEach((url, index) => {
+      // Stagger image downloads slightly so browsers don't block them
       setTimeout(() => {
         downloadFile(url, `design-${id}-image-${index + 1}.png`)
         URL.revokeObjectURL(url)
       }, (index + 1) * 200)
     })
   } catch (error) {
-    alert('Failed to download design')
+    alert('Failed to download design images')
     console.error('Error downloading canvas:', error)
   }
 }


### PR DESCRIPTION
## 📝 Description

Created a useCanvasExport composable that exports the tool image content to a png images and downloads them to the local machine.

Fixes #112

## 🔍 Type of change

- [x] New feature

## ✅ Checklist

- [x] Code follows project coding standards
- [x] All TypeScript types are properly defined
- [x] Components are properly documented
- [x] No console.logs in production code
- [x] Responsive design tested on all breakpoints
- [x] No ESLint errors or warnings
- [x] No security audit errors or warnings
- [ ] Lighthouse performance is still ok

## 💡 Additional context
