### PR TITLE
Added canvasStore to save and restore fabric.js canvas state

### DIFF
--- a/composables/useCanvasControls.ts
+++ b/composables/useCanvasControls.ts
@@ -1,0 +1,48 @@
+// composables/useCanvasControls.ts
+
+import { FabricImage, Textbox } from 'fabric'
+import type { Canvas, FabricObject } from 'fabric'
+import { useCustomImage } from '~/composables/useCustomImage'
+import { useCustomText } from '~/composables/useCustomText'
+
+/**
+ * Canvas Controls Composable
+ * @description Re-applies custom Fabric.js controls to canvas objects.
+ * Custom controls (renderers, event handlers) are functions and cannot be serialized
+ * to JSON, so they must be re-applied after restoring canvas state from JSON.
+ *
+ * Use `makeControlsReviver` as the reviver argument to `loadFromJSON` to fix
+ * controls immediately per-object as they are added, preventing mouse-event
+ * errors on partially-loaded canvases.
+ */
+
+export function useCanvasControls() {
+  const { applyImageControls } = useCustomImage()
+  const { applyTextboxControls } = useCustomText()
+
+  function reapplyControlsToObject(obj: FabricObject): void {
+    if (obj instanceof FabricImage) {
+      applyImageControls(obj)
+    } else if (obj instanceof Textbox) {
+      applyTextboxControls(obj)
+    }
+  }
+
+  function reapplyControls(canvas: Canvas): void {
+    canvas.getObjects().forEach(reapplyControlsToObject)
+  }
+
+  /**
+   * Returns a reviver function to pass to `canvas.loadFromJSON(json, reviver)`.
+   * Fixes controls on each object as it is added, before any mouse events can fire.
+   */
+  function makeControlsReviver() {
+    return (_data: Record<string, unknown>, obj: unknown): void => {
+      if (obj instanceof FabricImage || obj instanceof Textbox) {
+        reapplyControlsToObject(obj)
+      }
+    }
+  }
+
+  return { reapplyControls, reapplyControlsToObject, makeControlsReviver }
+}

--- a/composables/useCanvasRescale.ts
+++ b/composables/useCanvasRescale.ts
@@ -1,3 +1,5 @@
+// composables/useCanvasRescale.ts
+
 import type { Canvas, FabricImage } from 'fabric'
 
 /**

--- a/composables/useCanvasRescale.ts
+++ b/composables/useCanvasRescale.ts
@@ -1,0 +1,37 @@
+import type { Canvas, FabricImage } from 'fabric'
+
+/**
+ * Rescale Canvas Objects Composable
+ * @description Proportionally rescales canvas objects and background image by a given ratio.
+ * Used when the canvas viewport size changes to keep object positions and sizes
+ * proportional to the new canvas dimensions.
+ */
+
+export function useCanvasRescale() {
+  function rescaleBackground(canvas: Canvas, ratio: number): void {
+    const bg = canvas.backgroundImage as FabricImage | undefined
+    if (!bg) return
+
+    bg.set({
+      scaleX: (bg.scaleX ?? 1) * ratio,
+      scaleY: (bg.scaleY ?? 1) * ratio,
+      left: (bg.left ?? 0) * ratio,
+      top: (bg.top ?? 0) * ratio,
+    })
+    bg.setCoords()
+  }
+
+  function rescaleObjects(canvas: Canvas, ratio: number): void {
+    canvas.getObjects().forEach((obj) => {
+      obj.set({
+        left: (obj.left ?? 0) * ratio,
+        top: (obj.top ?? 0) * ratio,
+        scaleX: (obj.scaleX ?? 1) * ratio,
+        scaleY: (obj.scaleY ?? 1) * ratio,
+      })
+      obj.setCoords()
+    })
+  }
+
+  return { rescaleBackground, rescaleObjects }
+}

--- a/composables/useCustomImage.ts
+++ b/composables/useCustomImage.ts
@@ -19,6 +19,94 @@ interface Transform {
 
 export function useCustomImage() {
   /**
+   * Apply custom controls and appearance to a FabricImage.
+   * Called both when first adding and when restoring from JSON.
+   */
+  function applyImageControls(image: FabricImage): void {
+    // Clear default controls
+    image.controls = {}
+    // Configure the image
+    image.selectable = true
+    image.hasControls = true
+    image.hasBorders = true
+
+    // Add a blue dashed border for better visibility when selected
+    image.borderColor = 'blue'
+    image.borderScaleFactor = 1
+    image.borderDashArray = [5, 5]
+
+    // Disable caching to ensure controls are always rendered
+    image.objectCaching = false
+
+    // Add custom control for bring to front
+    image.controls.bringToFrontControl = new Control({
+      x: -0.5,
+      y: -0.5,
+      offsetX: -12,
+      offsetY: -12,
+      sizeX: 36,
+      sizeY: 36,
+      cursorStyle: 'pointer',
+      render: createBringToFrontControlRender(getBringToFrontImage()),
+      mouseUpHandler: (_eventData: unknown, transform: Transform): boolean => {
+        const target = transform?.target as FabricImage | undefined
+        if (target && target.canvas) {
+          toggleObjectZOrder(target, target.canvas)
+        }
+        return true
+      },
+    })
+
+    // Add custom control for delete
+    image.controls.deleteControl = new Control({
+      x: 0.5,
+      y: -0.5,
+      offsetX: 12,
+      offsetY: -12,
+      sizeX: 36,
+      sizeY: 36,
+      cursorStyle: 'pointer',
+      render: createTrashControlRender(getTrashCanImage()),
+      mouseUpHandler: (_eventData: unknown, transform: Transform): boolean => {
+        const target = transform?.target as FabricImage | undefined
+        if (target) {
+          const canvas = target.canvas
+          canvas?.remove(target)
+          canvas?.requestRenderAll()
+        }
+        return true
+      },
+    })
+    // Add custom control for rotation
+    image.controls.rotateControl = new Control({
+      x: 0,
+      y: -0.5,
+      offsetX: 0,
+      offsetY: -50,
+      sizeX: 36,
+      sizeY: 36,
+      cursorStyle: 'grab',
+      render: createRotateControlRender(getRotateImage()),
+      actionHandler: controlsUtils.rotationWithSnapping,
+      withConnection: true,
+    })
+
+    // Add custom control for resize
+    image.controls.resizeControl = new Control({
+      x: 0.5,
+      y: 0.5,
+      offsetX: 12,
+      offsetY: 12,
+      sizeX: 36,
+      sizeY: 36,
+      cursorStyle: 'nwse-resize',
+      render: createResizeControlRender(getResizeImage()),
+      withConnection: false,
+      actionHandler: controlsUtils.scalingEqually,
+    })
+  }
+
+  /**
    * Add a custom image to the canvas from a File object
    * Images are selectable, draggable, and have a delete button
    * @param canvas - The Fabric.js canvas instance
@@ -50,90 +138,11 @@ export function useCustomImage() {
       // Load the image using Fabric.js
       const image = await FabricImage.fromURL(dataUrl)
 
-      // Clear default controls
-      image.controls = {}
+      // Apply custom controls and styling
+      applyImageControls(image)
 
-      // Configure the image
-      image.selectable = true
-      image.hasControls = true
-      image.hasBorders = true
-      image.scaleToWidth(100) // Default size, can be adjusted
-
-      // Add a blue dashed border for better visibility when selected
-      image.borderColor = 'blue'
-      image.borderScaleFactor = 1
-      image.borderDashArray = [5, 5]
-
-      // Disable caching to ensure controls are always rendered
-      image.objectCaching = false
-
-      // Add custom control for bring to front
-      image.controls.bringToFrontControl = new Control({
-        x: -0.5,
-        y: -0.5,
-        offsetX: -12,
-        offsetY: -12,
-        sizeX: 36,
-        sizeY: 36,
-        cursorStyle: 'pointer',
-        render: createBringToFrontControlRender(getBringToFrontImage()),
-        mouseUpHandler: (_eventData: unknown, transform: Transform): boolean => {
-          const target = transform?.target as FabricImage | undefined
-          if (target && target.canvas) {
-            toggleObjectZOrder(target, target.canvas)
-          }
-          return true
-        },
-      })
-
-      // Add custom control for delete
-      image.controls.deleteControl = new Control({
-        x: 0.5,
-        y: -0.5,
-        offsetX: 12,
-        offsetY: -12,
-        sizeX: 36,
-        sizeY: 36,
-        cursorStyle: 'pointer',
-        render: createTrashControlRender(getTrashCanImage()),
-        mouseUpHandler: (_eventData: unknown, transform: Transform): boolean => {
-          const target = transform?.target as FabricImage | undefined
-          if (target) {
-            const canvas = target.canvas
-            canvas?.remove(target)
-            canvas?.requestRenderAll()
-          }
-          return true
-        },
-      })
-
-      // Add custom control for rotation
-      image.controls.rotateControl = new Control({
-        x: 0,
-        y: -0.5,
-        offsetX: 0,
-        offsetY: -50,
-        sizeX: 36,
-        sizeY: 36,
-        cursorStyle: 'grab',
-        render: createRotateControlRender(getRotateImage()),
-        actionHandler: controlsUtils.rotationWithSnapping,
-        withConnection: true,
-      })
-
-      // Add custom control for resize
-      image.controls.resizeControl = new Control({
-        x: 0.5,
-        y: 0.5,
-        offsetX: 12,
-        offsetY: 12,
-        sizeX: 36,
-        sizeY: 36,
-        cursorStyle: 'nwse-resize',
-        render: createResizeControlRender(getResizeImage()),
-        withConnection: false,
-        actionHandler: controlsUtils.scalingEqually,
-      })
+      // Default size for new images
+      image.scaleToWidth(100)
 
       // Center the image on the canvas
       canvas.centerObject(image)
@@ -155,6 +164,7 @@ export function useCustomImage() {
   }
 
   return {
+    applyImageControls,
     addImageToCanvas,
   }
 }

--- a/composables/useCustomText.ts
+++ b/composables/useCustomText.ts
@@ -37,9 +37,100 @@ const DEFAULT_TEXT_WIDTH = 360
 
 export function useCustomText() {
   /**
+   * Apply custom controls to an existing Textbox.
+   * Called both when first adding and when restoring from JSON.
+   */
+  function applyTextboxControls(textbox: Textbox): void {
+    textbox.controls = {
+      bringToFrontIcon: new Control({
+        x: -0.5,
+        y: -0.5,
+        offsetX: -12,
+        offsetY: -12,
+        sizeX: 36,
+        sizeY: 36,
+        cursorStyle: 'pointer',
+        render: createBringToFrontControlRender(getBringToFrontImage()),
+        mouseUpHandler: (eventData, transform) => {
+          const target = transform?.target
+          if (target && target.canvas) {
+            toggleObjectZOrder(target, target.canvas)
+          }
+        }
+      }),
+      scaleIcon: new Control({
+        x: 0.5,
+        y: 0.5,
+        offsetX: 12,
+        offsetY: 12,
+        sizeX: 36,
+        sizeY: 36,
+        render: createResizeControlRender(getResizeImage()),
+        cursorStyle: 'nwse-resize',
+        actionHandler: controlsUtils.scalingEqually,
+      }),
+      deleteIcon: new Control({
+        x: 0.5,
+        y: -0.5,
+        offsetX: 12,
+        offsetY: -12,
+        sizeX: 36,
+        sizeY: 36,
+        cursorStyle: 'pointer',
+        render: createTrashControlRender(getTrashCanImage()),
+        mouseUpHandler: (eventData, transform) => {
+          const target = transform?.target
+          if (target) {
+            const canvas = target.canvas
+            canvas?.remove(target)
+            canvas?.requestRenderAll()
+          }
+        }
+      }),
+      rotateIcon: new Control({
+        x: 0,
+        y: -0.5,
+        offsetY: -50,
+        cursorStyle: 'grab',
+        render: createRotateControlRender(getRotateImage()),
+        withConnection: true,
+        actionHandler: controlsUtils.rotationWithSnapping,
+      }),
+      resize: new Control({
+        x: -0.5,
+        y: 0.5,
+        cursorStyle: 'ew-resize',
+        offsetX: -12,
+        offsetY: 12,
+        sizeX: 36,
+        sizeY: 36,
+        render: (ctx, left, top, _styleOverride, fabricObject) => {
+          const size = 24
+          const img = getResizeImage()
+          ctx.save()
+          ctx.translate(left, top)
+          ctx.fillStyle = 'white'
+          ctx.rotate(util.degreesToRadians(fabricObject.angle || 0))
+          ctx.beginPath()
+          ctx.arc(0, 0, (3 * size) / 4, 0, Math.PI * 2)
+          ctx.fill()
+
+          if (img.complete) {
+            ctx.drawImage(img, -size / 2, -size / 2, size, size)
+          }
+
+          ctx.restore()
+        },
+        withConnection: true,
+        actionHandler: controlsUtils.changeObjectWidth,
+      }),
+    }
+  }
+
+  /**
    * Adds a textbox to a Fabric canvas (accepts a Vue Ref<Canvas | null>).
    */
-    function addTextToCanvas(canvas: FabricCanvasLike | null, options: AddTextOptions = {}): Textbox | null {
+  function addTextToCanvas(canvas: FabricCanvasLike | null, options: AddTextOptions = {}): Textbox | null {
     if (!canvas) return null
 
     const text = options.text ?? DEFAULT_TEXT
@@ -61,104 +152,20 @@ export function useCustomText() {
       borderScaleFactor: 1,
       borderDashArray: [5, 5],
       editable: true,
-      controls: {
-        bringToFrontIcon: new Control({
-          x: -0.5,
-          y: -0.5,
-          offsetX: -12,
-          offsetY: -12,
-          sizeX: 36,
-          sizeY: 36,
-          cursorStyle: 'pointer',
-          render: createBringToFrontControlRender(getBringToFrontImage()),
-          mouseUpHandler: (eventData, transform) => {
-            const target = transform?.target
-            if (target && target.canvas) {
-              toggleObjectZOrder(target, target.canvas)
-            }
-          }
-        }),
-        scaleIcon: new Control({
-          x: 0.5,
-          y: 0.5,
-          offsetX: 12,
-          offsetY: 12,
-          sizeX: 36,
-          sizeY: 36,
-          render: createResizeControlRender(getResizeImage()),
-          cursorStyle: 'nwse-resize',
-          actionHandler: controlsUtils.scalingEqually,
-        }),
-        deleteIcon: new Control({
-          x: 0.5,
-          y: -0.5,
-          offsetX: 12,
-          offsetY: -12,
-          sizeX: 36,
-          sizeY: 36,
-          cursorStyle: 'pointer',
-          render: createTrashControlRender(getTrashCanImage()),
-          mouseUpHandler: (eventData, transform) => {          
-            const target = transform?.target
-            if (target) {
-              const canvas = target.canvas
-              canvas?.remove(target)
-              canvas?.requestRenderAll()
-            }
-          }
-        }),
-        rotateIcon: new Control({
-          x: 0,
-          y: -0.5,
-          offsetY: -50,
-          cursorStyle: 'grab',
-          render: createRotateControlRender(getRotateImage()),
-          withConnection: true,
-          actionHandler: controlsUtils.rotationWithSnapping,
-        }),
-        resize: new Control({
-          x: -0.5,
-          y: 0.5,
-          cursorStyle: 'ew-resize',
-          offsetX: -12,
-          offsetY: 12,
-          sizeX: 36,
-          sizeY: 36,
-          render: (ctx, left, top, _styleOverride, fabricObject) => {
-            const size = 24
-            const img = getResizeImage()
-            ctx.save()
-                ctx.translate(left, top)
-                ctx.fillStyle = 'white'
-                ctx.rotate(util.degreesToRadians(fabricObject.angle || 0))
-                ctx.beginPath()
-                ctx.arc(0, 0, (3 * size) / 4, 0, Math.PI * 2)
-                ctx.fill()
+    })
 
-                if (img.complete) {
-                  ctx.drawImage(img, -size / 2, -size / 2, size, size)
-                }
-
-            ctx.restore()
-
-          },
-          withConnection: true,
-          actionHandler: controlsUtils.changeObjectWidth,
-        }),
-        
-    }})
-
-    
+    applyTextboxControls(textbox)
 
     canvas.add(textbox)
     canvas.centerObject(textbox)
     canvas.setActiveObject(textbox)
     canvas.requestRenderAll()
-    
+
     return textbox
   }
 
   return {
+    applyTextboxControls,
     addTextToCanvas,
   }
 }

--- a/composables/useCustomText.ts
+++ b/composables/useCustomText.ts
@@ -1,4 +1,5 @@
 // composables/useCustomText.ts
+
 import { Textbox, Control, controlsUtils, util } from 'fabric'
 import {
   createResizeControlRender,

--- a/pages/custom-design.vue
+++ b/pages/custom-design.vue
@@ -5,17 +5,19 @@
 import '~/assets/css/custom-design-fonts.css'
 import { Canvas, FabricImage, ActiveSelection, Control, controlsUtils } from 'fabric'
 import { nanoid } from 'nanoid'
+import ImageIcon from '~/assets/images/custom-design/image-icon.svg?component'
+import TextIcon from '~/assets/images/custom-design/text-icon.svg?component'
 import HeroImage from '~/components/common/HeroImage.vue'
 import Section from '~/components/common/Section.vue'
 import IconButton from '~/components/common/IconButton.vue'
-import ImageIcon from '~/assets/images/custom-design/image-icon.svg?component'
-import TextIcon from '~/assets/images/custom-design/text-icon.svg?component'
 import TextButton from '~/components/common/TextButton.vue'
+import TextboxControls from '~/components/features/TextboxControls.vue'
 import { useCustomImage } from '~/composables/useCustomImage'
 import { useCustomText } from '~/composables/useCustomText'
 import { useCanvasExport } from '~/composables/useCanvasExport'
+import { useCanvasRescale } from '~/composables/useCanvasRescale'
+import { useCanvasStore } from '@/stores/canvasStore'
 import { ref, shallowRef, onMounted, onBeforeUnmount } from 'vue'
-import TextboxControls from '~/components/features/TextboxControls.vue'
 import {
   createRotateControlRender,
   createTrashControlRender,
@@ -56,6 +58,8 @@ useHead({
 const { addImageToCanvas } = useCustomImage()
 const { addTextToCanvas } = useCustomText()
 const { exportMergedImage, exportImageObjects } = useCanvasExport()
+const { rescaleObjects } = useCanvasRescale()
+const canvasStore = useCanvasStore()
 
 // ===== STATE =====
 const fileInputRef = ref<HTMLInputElement | null>(null)
@@ -141,15 +145,34 @@ onMounted(async () => {
 
 onBeforeUnmount(() => {
   resizeObserver?.disconnect()
+  if(canvas.value) {
+    // Save state before leaving page
+    canvasStore.save(canvas.value, currentCanvasSize)
+    // Cleanup (important)
+    canvas.value.dispose()
+  }
 })
 
 async function initializeCanvas(el: HTMLCanvasElement, size: number): Promise<void> {
   currentCanvasSize = size
   canvas.value = new Canvas(el, { selection: true })
+  if(!canvas.value) {
+    console.error('Failed to initialize Fabric canvas')
+    return
+  }
   canvas.value.setDimensions({ width: size, height: size })
   canvas.value.enablePointerEvents = true
 
   await loadBackground('/images/custom-design/t-shirt-front.png', size)
+
+  // Restore previous state, rescaling objects if the viewport size changed
+  await canvasStore.restore(canvas.value, size)
+
+  // Watch for canvas changes and save state
+  canvas.value.on('object:added', () => canvasStore.save(canvas.value!, currentCanvasSize))
+  canvas.value.on('object:modified', () => canvasStore.save(canvas.value!, currentCanvasSize))
+  canvas.value.on('object:removed', () => canvasStore.save(canvas.value!, currentCanvasSize))
+
 }
 
 async function loadBackground(url: string, size: number = currentCanvasSize): Promise<void> {
@@ -181,16 +204,7 @@ function rescaleCanvas(newSize: number): void {
   }
 
   // Proportionally rescale and reposition all objects
-  canvas.value.getObjects().forEach((obj) => {
-    obj.set({
-      left: (obj.left ?? 0) * ratio,
-      top: (obj.top ?? 0) * ratio,
-      scaleX: (obj.scaleX ?? 1) * ratio,
-      scaleY: (obj.scaleY ?? 1) * ratio,
-    })
-    obj.setCoords()
-  })
-
+  rescaleObjects(canvas.value, ratio)
   canvas.value.requestRenderAll()
 }
 

--- a/stores/canvasStore.ts
+++ b/stores/canvasStore.ts
@@ -1,0 +1,54 @@
+// stores/canvasStore.ts
+
+import { defineStore } from 'pinia'
+import type { Canvas } from 'fabric'
+import { useCanvasRescale } from '~/composables/useCanvasRescale'
+import { useCanvasControls } from '~/composables/useCanvasControls'
+
+/** 
+ * Canvas Store
+ * @description Manages the state of the canvas, allowing saving and restoring
+ * the canvas state as JSON. This is useful for features like undo/redo or
+ * persisting the canvas state across sessions.
+ * 
+ * @example
+ * const canvasStore = useCanvasStore()
+ * canvasStore.save(canvas, canvasSize)
+ * // ... later or on page reload ...
+ * canvasStore.restore(canvas, currentCanvasSize)
+ */
+
+export const useCanvasStore = defineStore('canvas', {
+  state: () => ({
+    json: null as string | null,
+    size: 0,
+  }),
+  actions: {
+    save(canvas: Canvas, size: number) {
+      this.json = JSON.stringify(canvas.toJSON())
+      this.size = size
+    },
+    async restore(canvas: Canvas, currentSize: number) {
+      if (!this.json) return
+
+      // Re-apply custom controls via reviver so each object is fixed immediately
+      // as it is added during loadFromJSON — before any mouse events can fire.
+      const { makeControlsReviver } = useCanvasControls()
+      await canvas.loadFromJSON(this.json, makeControlsReviver())
+
+      // Rescale objects and background if the canvas size changed since last save
+      if (this.size > 0 && this.size !== currentSize) {
+        const ratio = currentSize / this.size
+        const { rescaleBackground, rescaleObjects } = useCanvasRescale()
+        rescaleBackground(canvas, ratio)
+        rescaleObjects(canvas, ratio)
+      }
+
+      canvas.requestRenderAll()
+    },
+    clear() {
+      this.json = null
+      this.size = 0
+    }
+  }
+})


### PR DESCRIPTION
## 📝 Description

Added canvasStore to save and restore fabric.js canvas state so that content in Custom Image tool doesn't disappears when navigating to other page.

Fixes #117

## 🔍 Type of change

- [x] New feature

## ✅ Checklist

- [x] Code follows project coding standards
- [x] All TypeScript types are properly defined
- [x] Components are properly documented
- [x] No console.logs in production code
- [x] Responsive design tested on all breakpoints
- [x] No ESLint errors or warnings
- [x] No security audit errors or warnings
- [ ] Lighthouse performance is still ok

## 💡 Additional context
