### PR TITLE
Add front/back selector to Custom Image tool 

### DIFF
--- a/components/features/BackgroundSelector.vue
+++ b/components/features/BackgroundSelector.vue
@@ -251,7 +251,7 @@ watch(
 
 <template>
   <div class="w-full max-w-xl mx-auto my-4 px-4 justify-center flex">
-    <div class="flex flex-col sm:flex-row items-stretch sm:items-center gap-3 p-3 bg-white border border-gray-300 rounded-lg shadow-md">
+    <div class="flex items-stretch sm:items-center gap-3 p-3 bg-white border border-gray-300 rounded-lg shadow-md justify-center flex-wrap">
       <label class="flex items-center gap-3 flex-1">
         <select
           v-model="selectedBackground"
@@ -267,15 +267,15 @@ watch(
           </option>
         </select>
       </label>
-      <label class="flex items-center gap-3">
+      <label class="flex  sm:w-auto items-center gap-3">
         <select
           :value="props.side"
-          class="h-11 px-3 py-2 border border-gray-300 rounded-md bg-gray-50 cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          class="h-11 px-3 py-2 border w-full border-gray-300 rounded-md bg-gray-50 cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
           aria-label="Select side"
           @change="emit('sideChanged', ($event.target as HTMLSelectElement).value as CanvasSide)"
         >
-          <option value="front">Framsida</option>
-          <option value="back">Baksida</option>
+          <option value="front">Fram</option>
+          <option value="back">Bak</option>
         </select>
       </label>
 

--- a/components/features/BackgroundSelector.vue
+++ b/components/features/BackgroundSelector.vue
@@ -1,56 +1,81 @@
 <script setup lang="ts">
 // 1. Imports
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import type { Canvas } from 'fabric'
 import { FabricImage } from 'fabric'
 import { storeToRefs } from 'pinia'
-import { useCanvasStore } from '@/stores/canvasStore'
+import { useCanvasStore, type CanvasSide } from '@/stores/canvasStore'
 
 // 2. Props & Emits
 interface Props {
   canvas: Canvas | null
-  currentBackgroundUrl?: string
+  side: CanvasSide
 }
 
 const props = defineProps<Props>()
 const emit = defineEmits<{
-  backgroundChanged: [url: string]
+  sideChanged: [side: CanvasSide]
 }>()
 
 // 3. Composables & Stores
 const canvasStore = useCanvasStore()
-const { backgroundSelection, customBackgroundDataUrl } = storeToRefs(canvasStore)
+const { front, back } = storeToRefs(canvasStore)
 
 // 4. State
 const CUSTOM_OPTION_ID = 'custom'
 
-const backgrounds = [
-  {
-    id: 'tshirt',
-    label: 'T-Shirt',
-    url: '/images/custom-design/t-shirt-front.png',
-  },
-  {
-    id: 'baseball-cap',
-    label: 'Baseball Keps',
-    url: '/images/custom-design/baseball-cap-front.png',
-  },
-  {
-    id: 'jacket',
-    label: 'Jacka',
-    url: '/images/custom-design/jacket-front.png',
-  },
+const backgroundOptionsBySide = {
+  front: [
+    {
+      id: 'tshirt',
+      label: 'T-Shirt',
+      url: '/images/custom-design/t-shirt-front.png',
+    },
+    {
+      id: 'baseball-cap',
+      label: 'Baseball Keps',
+      url: '/images/custom-design/baseball-cap-front.png',
+    },
+    {
+      id: 'jacket',
+      label: 'Jacka',
+      url: '/images/custom-design/jacket-front.png',
+    },
+  ],
+  back: [
+    {
+      id: 'tshirt',
+      label: 'T-Shirt',
+      url: '/images/custom-design/t-shirt-back.png',
+    },
+    {
+      id: 'baseball-cap',
+      label: 'Baseball Keps',
+      url: '/images/custom-design/baseball-cap-back.png',
+    },
+    {
+      id: 'jacket',
+      label: 'Jacka',
+      url: '/images/custom-design/jacket-back.png',
+    },
+  ],
+} satisfies Record<CanvasSide, Array<{ id: string; label: string; url: string }>>
+
+const customFileInputRef = ref<HTMLInputElement | null>(null)
+
+const sideState = computed(() => (props.side === 'front' ? front.value : back.value))
+
+const backgroundOptions = computed(() => [
+  ...backgroundOptionsBySide[props.side],
   {
     id: CUSTOM_OPTION_ID,
     label: 'Egen Produkt',
     url: CUSTOM_OPTION_ID,
   },
-]
-
-const customFileInputRef = ref<HTMLInputElement | null>(null)
+])
 
 const selectedBackground = computed({
-  get: () => props.currentBackgroundUrl || backgroundSelection.value || backgrounds[0].url,
+  get: () => sideState.value.backgroundSelection || backgroundOptions.value[0].url,
   set: (url: string) => {
     if (url === CUSTOM_OPTION_ID) {
       selectCustomBackground()
@@ -81,12 +106,28 @@ async function loadBackground(url: string): Promise<void> {
     canvasInstance.backgroundImage = bg
     canvasInstance.requestRenderAll()
 
-    canvasStore.setBackgroundSelection(url)
-
-    emit('backgroundChanged', url)
+    resetStoredCanvases(url)
+    syncProductSelection(url)
   } catch (error) {
     console.error('Failed to load background image:', error)
   }
+}
+
+function resetStoredCanvases(url: string): void {
+  if (url === CUSTOM_OPTION_ID) return
+  canvasStore.clear()
+}
+
+function syncProductSelection(url: string): void {
+  if (url === CUSTOM_OPTION_ID) return
+
+  const otherSide = getOtherSide(props.side)
+  const mappedUrl = mapBackgroundUrlToSide(url, otherSide)
+
+  canvasStore.setBackgroundSelection(props.side, url)
+  canvasStore.setCustomBackgroundDataUrl(props.side, null)
+  canvasStore.setBackgroundSelection(otherSide, mappedUrl)
+  canvasStore.setCustomBackgroundDataUrl(otherSide, null)
 }
 
 function clearBackground(): void {
@@ -97,8 +138,9 @@ function clearBackground(): void {
 }
 
 function selectCustomBackground(): void {
-  const storedDataUrl = customBackgroundDataUrl.value
-  canvasStore.setBackgroundSelection(CUSTOM_OPTION_ID)
+  const storedDataUrl = sideState.value.customBackgroundDataUrl
+  canvasStore.setBackgroundSelection(props.side, CUSTOM_OPTION_ID)
+  canvasStore.setBackgroundSelection(getOtherSide(props.side), CUSTOM_OPTION_ID)
 
   if (storedDataUrl) {
     applyCustomBackground(storedDataUrl)
@@ -106,7 +148,6 @@ function selectCustomBackground(): void {
   }
 
   clearBackground()
-  emit('backgroundChanged', CUSTOM_OPTION_ID)
 }
 
 function openCustomFileDialog(): void {
@@ -139,10 +180,8 @@ async function applyCustomBackground(dataUrl: string): Promise<void> {
     canvasInstance.backgroundImage = bg
     canvasInstance.requestRenderAll()
 
-    canvasStore.setBackgroundSelection(CUSTOM_OPTION_ID)
-    canvasStore.setCustomBackgroundDataUrl(dataUrl)
-
-    emit('backgroundChanged', dataUrl)
+    canvasStore.setBackgroundSelection(props.side, CUSTOM_OPTION_ID)
+    canvasStore.setCustomBackgroundDataUrl(props.side, dataUrl)
   } catch (error) {
     console.error('Failed to load custom background image:', error)
   }
@@ -168,12 +207,11 @@ async function handleCustomFileSelected(event: Event): Promise<void> {
   input.value = ''
 }
 
-// 7. Lifecycle hooks
-onMounted(() => {
-  const selection = backgroundSelection.value
+function hydrateFromStore(): void {
+  const selection = sideState.value.backgroundSelection
   if (selection === CUSTOM_OPTION_ID) {
-    if (customBackgroundDataUrl.value) {
-      applyCustomBackground(customBackgroundDataUrl.value)
+    if (sideState.value.customBackgroundDataUrl) {
+      applyCustomBackground(sideState.value.customBackgroundDataUrl)
     } else {
       clearBackground()
     }
@@ -183,15 +221,37 @@ onMounted(() => {
   if (selection && selection !== selectedBackground.value) {
     loadBackground(selection)
   }
+}
+
+function getOtherSide(side: CanvasSide): CanvasSide {
+  return side === 'front' ? 'back' : 'front'
+}
+
+function mapBackgroundUrlToSide(url: string, side: CanvasSide): string {
+  if (side === 'front') {
+    return url.replace('-back.', '-front.')
+  }
+
+  return url.replace('-front.', '-back.')
+}
+
+// 7. Lifecycle hooks
+onMounted(() => {
+  hydrateFromStore()
 })
 
 // 8. Watchers
-// (none)
+watch(
+  () => [props.side, props.canvas],
+  () => {
+    hydrateFromStore()
+  },
+)
 </script>
 
 <template>
   <div class="w-full max-w-xl mx-auto my-4 px-4 justify-center flex">
-    <div class="flex flex-col max-w-sm sm:flex-row items-stretch sm:items-center gap-3 sm:gap-3 p-3 sm:p-3 bg-white border border-gray-300 rounded-lg shadow-md">
+    <div class="flex flex-col sm:flex-row items-stretch sm:items-center gap-3 p-3 bg-white border border-gray-300 rounded-lg shadow-md">
       <label class="flex items-center gap-3 flex-1">
         <select
           v-model="selectedBackground"
@@ -199,7 +259,7 @@ onMounted(() => {
           aria-label="Select canvas background"
         >
           <option
-            v-for="bg in backgrounds"
+            v-for="bg in backgroundOptions"
             :key="bg.id"
             :value="bg.url"
           >
@@ -207,6 +267,18 @@ onMounted(() => {
           </option>
         </select>
       </label>
+      <label class="flex items-center gap-3">
+        <select
+          :value="props.side"
+          class="h-11 px-3 py-2 border border-gray-300 rounded-md bg-gray-50 cursor-pointer focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          aria-label="Select side"
+          @change="emit('sideChanged', ($event.target as HTMLSelectElement).value as CanvasSide)"
+        >
+          <option value="front">Framsida</option>
+          <option value="back">Baksida</option>
+        </select>
+      </label>
+
       <button
         v-if="isCustomSelected"
         class="inline-flex items-center justify-center h-11 px-4 text-sm font-semibold rounded-button bg-primary-600 text-white shadow-sm transition hover:bg-primary-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-600"

--- a/composables/useCustomText.ts
+++ b/composables/useCustomText.ts
@@ -31,7 +31,7 @@ export interface AddTextOptions {
 const DEFAULT_TEXT = 'Min text'
 const DEFAULT_FONT_SIZE = 36
 const DEFAULT_FONT_FAMILY = "'Inter', sans-serif"
-const DEFAULT_FONT_WEIGHT = 600
+const DEFAULT_FONT_WEIGHT = 400
 const DEFAULT_FILL = '#111111'
 const DEFAULT_TEXT_ALIGN: AddTextOptions['textAlign'] = 'center'
 const DEFAULT_TEXT_WIDTH = 360

--- a/pages/custom-design.vue
+++ b/pages/custom-design.vue
@@ -16,8 +16,9 @@ import { useCustomImage } from '~/composables/useCustomImage'
 import { useCustomText } from '~/composables/useCustomText'
 import { useCanvasExport } from '~/composables/useCanvasExport'
 import { useCanvasRescale } from '~/composables/useCanvasRescale'
-import { useCanvasStore } from '@/stores/canvasStore'
-import { ref, shallowRef, onMounted, onBeforeUnmount } from 'vue'
+import { useCanvasStore, type CanvasSide } from '@/stores/canvasStore'
+import { computed, nextTick, ref, shallowRef, onMounted, onBeforeUnmount, watch } from 'vue'
+import { storeToRefs } from 'pinia'
 import BackgroundSelector from '~/components/features/BackgroundSelector.vue'
 import {
   createRotateControlRender,
@@ -62,21 +63,54 @@ const { exportMergedImage, exportImageObjects } = useCanvasExport()
 const { rescaleObjects } = useCanvasRescale()
 const canvasStore = useCanvasStore()
 
+const CUSTOM_BACKGROUND_SELECTION = 'custom'
+
 // ===== STATE =====
 const fileInputRef = ref<HTMLInputElement | null>(null)
-const canvas = shallowRef<Canvas | null>(null)
+const frontCanvasRef = ref<HTMLCanvasElement | null>(null)
+const backCanvasRef = ref<HTMLCanvasElement | null>(null)
 const canvasWrapperRef = ref<HTMLDivElement | null>(null)
+const activeSide = ref<CanvasSide>('front')
+const frontCanvas = shallowRef<Canvas | null>(null)
+const backCanvas = shallowRef<Canvas | null>(null)
 let resizeObserver: ResizeObserver | null = null
 let currentCanvasSize = 0
+
+// ===== COMPUTED =====
+const activeCanvas = computed(() => (activeSide.value === 'front' ? frontCanvas.value : backCanvas.value))
+
+// ===== WATCHERS =====
+const { front: frontState, back: backState } = storeToRefs(canvasStore)
+
+watch(() => frontState.value.backgroundSelection, async (newSelection) => {
+  if (!frontCanvas.value || !newSelection) return
+  if (newSelection === CUSTOM_BACKGROUND_SELECTION) {
+    frontCanvas.value.backgroundImage = undefined
+    frontCanvas.value.requestRenderAll()
+    return
+  }
+  await loadBackgroundOnCanvas(frontCanvas.value, newSelection)
+})
+
+watch(() => backState.value.backgroundSelection, async (newSelection) => {
+  if (!backCanvas.value || !newSelection) return
+  if (newSelection === CUSTOM_BACKGROUND_SELECTION) {
+    backCanvas.value.backgroundImage = undefined
+    backCanvas.value.requestRenderAll()
+    return
+  }
+  await loadBackgroundOnCanvas(backCanvas.value, newSelection)
+})
 
 // ===== LIFECYCLE HOOKS =====
 onMounted(async () => {
   await nextTick()
-  const el = document.getElementById('shirt-canvas') as HTMLCanvasElement
+  const frontEl = frontCanvasRef.value
+  const backEl = backCanvasRef.value
   const wrapper = canvasWrapperRef.value
 
-    // Validate element exists and is a canvas
-  if (!(el instanceof HTMLCanvasElement) || !wrapper) {
+  // Validate elements exist and are canvases
+  if (!(frontEl instanceof HTMLCanvasElement) || !(backEl instanceof HTMLCanvasElement) || !wrapper) {
     console.error('Canvas element not found')
     return
   }
@@ -135,10 +169,25 @@ onMounted(async () => {
   resizeObserver = new ResizeObserver((entries) => {
     const size = Math.ceil(entries[0].contentRect.width)
     if (size <= 0) return
-    if (!canvas.value) {
-      initializeCanvas(el, size)
-    } else {
-      rescaleCanvas(size)
+
+    const previousSize = currentCanvasSize
+    if (previousSize > 0 && size !== previousSize) {
+      const ratio = size / previousSize
+      if (frontCanvas.value) {
+        rescaleCanvas(frontCanvas.value, ratio, size)
+      }
+      if (backCanvas.value) {
+        rescaleCanvas(backCanvas.value, ratio, size)
+      }
+    }
+
+    currentCanvasSize = size
+
+    if (!frontCanvas.value) {
+      void initializeCanvas('front', frontEl, size)
+    }
+    if (!backCanvas.value) {
+      void initializeCanvas('back', backEl, size)
     }
   })
   resizeObserver.observe(wrapper)
@@ -146,58 +195,97 @@ onMounted(async () => {
 
 onBeforeUnmount(() => {
   resizeObserver?.disconnect()
-  if(canvas.value) {
-    // Save state before leaving page
-    canvasStore.save(canvas.value, currentCanvasSize)
-    // Cleanup (important)
-    canvas.value.dispose()
+  if (frontCanvas.value) {
+    canvasStore.save('front', frontCanvas.value, currentCanvasSize)
+    frontCanvas.value.dispose()
+  }
+  if (backCanvas.value) {
+    canvasStore.save('back', backCanvas.value, currentCanvasSize)
+    backCanvas.value.dispose()
   }
 })
 
-async function initializeCanvas(el: HTMLCanvasElement, size: number): Promise<void> {
-  currentCanvasSize = size
-  canvas.value = new Canvas(el, { selection: true })
-  if(!canvas.value) {
+async function initializeCanvas(side: CanvasSide, el: HTMLCanvasElement, size: number): Promise<void> {
+  const canvasInstance = new Canvas(el, { selection: true })
+  if (!canvasInstance) {
     console.error('Failed to initialize Fabric canvas')
     return
   }
-  canvas.value.setDimensions({ width: size, height: size })
-  canvas.value.enablePointerEvents = true
 
-  await loadBackground('/images/custom-design/t-shirt-front.png', size)
+  if (side === 'front') {
+    frontCanvas.value = canvasInstance
+  } else {
+    backCanvas.value = canvasInstance
+  }
 
-  // Restore previous state, rescaling objects if the viewport size changed
-  await canvasStore.restore(canvas.value, size)
+  canvasInstance.setDimensions({ width: size, height: size })
+  canvasInstance.enablePointerEvents = true
 
-  // Watch for canvas changes and save state
-  canvas.value.on('object:added', () => canvasStore.save(canvas.value!, currentCanvasSize))
-  canvas.value.on('object:modified', () => canvasStore.save(canvas.value!, currentCanvasSize))
-  canvas.value.on('object:removed', () => canvasStore.save(canvas.value!, currentCanvasSize))
+  await canvasStore.restore(side, canvasInstance, size)
 
+  if (!canvasInstance.backgroundImage) {
+    const initialBackgroundUrl = getInitialBackgroundUrl(side)
+    await loadBackgroundOnCanvas(canvasInstance, initialBackgroundUrl, size)
+    const sideState = getSideState(side)
+    if (!sideState.backgroundSelection && initialBackgroundUrl) {
+      canvasStore.setBackgroundSelection(side, initialBackgroundUrl)
+    }
+  }
+
+  canvasInstance.on('object:added', () => canvasStore.save(side, canvasInstance, currentCanvasSize))
+  canvasInstance.on('object:modified', () => canvasStore.save(side, canvasInstance, currentCanvasSize))
+  canvasInstance.on('object:removed', () => canvasStore.save(side, canvasInstance, currentCanvasSize))
 }
 
-async function loadBackground(url: string, size: number = currentCanvasSize): Promise<void> {
-  if (!canvas.value) return
+function getDefaultBackgroundUrl(side: CanvasSide): string {
+  return side === 'front'
+    ? '/images/custom-design/t-shirt-front.png'
+    : '/images/custom-design/t-shirt-back.png'
+}
 
+function getSideState(side: CanvasSide) {
+  return side === 'front' ? canvasStore.front : canvasStore.back
+}
+
+function getInitialBackgroundUrl(side: CanvasSide): string {
+  const sideState = getSideState(side)
+  if (sideState.backgroundSelection && sideState.backgroundSelection !== CUSTOM_BACKGROUND_SELECTION) {
+    return sideState.backgroundSelection
+  }
+
+  const otherSide = side === 'front' ? 'back' : 'front'
+  const otherState = getSideState(otherSide)
+  if (otherState.backgroundSelection && otherState.backgroundSelection !== CUSTOM_BACKGROUND_SELECTION) {
+    return mapBackgroundUrlToSide(otherState.backgroundSelection, side)
+  }
+
+  return getDefaultBackgroundUrl(side)
+}
+
+function mapBackgroundUrlToSide(url: string, side: CanvasSide): string {
+  if (side === 'front') {
+    return url.replace('-back.', '-front.')
+  }
+
+  return url.replace('-front.', '-back.')
+}
+
+async function loadBackgroundOnCanvas(canvasInstance: Canvas, url: string, size: number = currentCanvasSize): Promise<void> {
   const bg = await FabricImage.fromURL(url)
   bg.scaleToWidth(size)
   bg.scaleToHeight(size)
   bg.selectable = false
   bg.evented = false
   bg.set({ originX: 'center', originY: 'center', left: size / 2, top: size / 2 })
-  canvas.value.backgroundImage = bg
-  canvas.value.requestRenderAll()
+  canvasInstance.backgroundImage = bg
+  canvasInstance.requestRenderAll()
 }
 
-function rescaleCanvas(newSize: number): void {
-  if (!canvas.value || currentCanvasSize <= 0) return
-  const ratio = newSize / currentCanvasSize
-  currentCanvasSize = newSize
+function rescaleCanvas(canvasInstance: Canvas, ratio: number, newSize: number): void {
+  canvasInstance.setDimensions({ width: newSize, height: newSize })
 
-  canvas.value.setDimensions({ width: newSize, height: newSize })
-
-  // Rescale background image
-  const bg = canvas.value.backgroundImage as FabricImage | undefined
+    // Rescale background image
+  const bg = canvasInstance.backgroundImage as FabricImage | undefined
   if (bg) {
     bg.scaleToWidth(newSize)
     bg.scaleToHeight(newSize)
@@ -205,8 +293,8 @@ function rescaleCanvas(newSize: number): void {
   }
 
   // Proportionally rescale and reposition all objects
-  rescaleObjects(canvas.value, ratio)
-  canvas.value.requestRenderAll()
+  rescaleObjects(canvasInstance, ratio)
+  canvasInstance.requestRenderAll()
 }
 
 function uploadImage(): void {
@@ -218,7 +306,8 @@ async function handleImageSelected(event: Event): Promise<void> {
   const input = event.target as HTMLInputElement
   const file = input.files?.[0]
 
-  if (!file || !canvas.value) return
+  const canvasInstance = activeCanvas.value
+  if (!file || !canvasInstance) return
 
   // Validate that it's an image
   if (!file.type.startsWith('image/')) {
@@ -227,7 +316,7 @@ async function handleImageSelected(event: Event): Promise<void> {
   }
 
   try {
-    await addImageToCanvas(canvas.value as Canvas, file)
+    await addImageToCanvas(canvasInstance, file)
   } catch (error) {
     alert('Failed to add image. Please try again.')
     console.error('Error adding image:', error)
@@ -238,7 +327,7 @@ async function handleImageSelected(event: Event): Promise<void> {
 }
 
 function addText() {
-  addTextToCanvas(canvas.value)
+  addTextToCanvas(activeCanvas.value)
 }
 
 function downloadFile(dataURL: string, filename: string): void {
@@ -249,7 +338,12 @@ function downloadFile(dataURL: string, filename: string): void {
 }
 
 async function downloadCanvasImages(): Promise<void> {
-  if (!canvas.value) {
+  const availableCanvases = [
+    { side: 'front' as const, canvas: frontCanvas.value },
+    { side: 'back' as const, canvas: backCanvas.value },
+  ].filter(entry => entry.canvas)
+
+  if (availableCanvases.length === 0) {
     alert('Canvas not initialized')
     console.error('Error downloading canvas: Canvas is not initialized')
     return
@@ -257,23 +351,26 @@ async function downloadCanvasImages(): Promise<void> {
 
   try {
     const id = nanoid(10)
-    const [mergedUrl, imageUrls] = await Promise.all([
-      exportMergedImage(canvas.value),
-      exportImageObjects(canvas.value),
-    ])
+    for (const entry of availableCanvases) {
+      const canvasInstance = entry.canvas as Canvas
+      const [mergedUrl, imageUrls] = await Promise.all([
+        exportMergedImage(canvasInstance),
+        exportImageObjects(canvasInstance),
+      ])
 
-    // Download merged image first
-    downloadFile(mergedUrl, `design-${id}.png`)
-    URL.revokeObjectURL(mergedUrl)
+      // Download merged image first
+      downloadFile(mergedUrl, `design-${id}-${entry.side}.png`)
+      URL.revokeObjectURL(mergedUrl)
 
-    // Download individual layer images
-    imageUrls.forEach((url, index) => {
-      // Stagger image downloads slightly so browsers don't block them
-      setTimeout(() => {
-        downloadFile(url, `design-${id}-image-${index + 1}.png`)
-        URL.revokeObjectURL(url)
-      }, (index + 1) * 200)
-    })
+      // Download individual layer images
+      imageUrls.forEach((url, index) => {
+        // Stagger image downloads slightly so browsers don't block them
+        setTimeout(() => {
+          downloadFile(url, `design-${id}-${entry.side}-image-${index + 1}.png`)
+          URL.revokeObjectURL(url)
+        }, (index + 1) * 200)
+      })
+    }
   } catch (error) {
     alert('Failed to download design images')
     console.error('Error downloading canvas:', error)
@@ -311,10 +408,21 @@ async function downloadCanvasImages(): Promise<void> {
         align="center"
         aria-label="Design Verktyg"
       >
-        <BackgroundSelector :canvas="canvas" />
+        <BackgroundSelector :canvas="activeCanvas" :side="activeSide" @side-changed="activeSide = $event" />
         <div class="designer flex flex-col sm:flex-row gap-4 items-center justify-center">
-          <div ref="canvasWrapperRef" class="flex-1 w-full min-w-[350px] max-w-[800px] aspect-square">
-            <canvas id="shirt-canvas" class="block border border-black rounded-card overflow-hidden"/>
+          <div ref="canvasWrapperRef" class="relative flex-1 w-full min-w-[350px] max-w-[800px] aspect-square">
+            <div v-show="activeSide === 'front'" class="absolute inset-0" :aria-hidden="activeSide !== 'front'">
+              <canvas
+                ref="frontCanvasRef"
+                class="block w-full h-full border border-black rounded-card overflow-hidden"
+              />
+            </div>
+            <div v-show="activeSide === 'back'" class="absolute inset-0" :aria-hidden="activeSide !== 'back'">
+              <canvas
+                ref="backCanvasRef"
+                class="block w-full h-full border border-black rounded-card overflow-hidden"
+              />
+            </div>
           </div>
           <div class="flex flex-row sm:flex-col justify-center gap-3">
             <IconButton
@@ -339,7 +447,7 @@ async function downloadCanvasImages(): Promise<void> {
             </IconButton>
           </div>
         </div>
-        <TextboxControls :canvas="canvas" />
+        <TextboxControls :canvas="activeCanvas" />
         <div class="mt-24 flex justify-center gap-4">
           <TextButton @click="downloadCanvasImages">Begär Offert</TextButton>
         </div>

--- a/pages/custom-design.vue
+++ b/pages/custom-design.vue
@@ -84,6 +84,7 @@ const { front: frontState, back: backState } = storeToRefs(canvasStore)
 
 watch(() => frontState.value.backgroundSelection, async (newSelection) => {
   if (!frontCanvas.value || !newSelection) return
+  frontCanvas.value.remove(...frontCanvas.value.getObjects())
   if (newSelection === CUSTOM_BACKGROUND_SELECTION) {
     frontCanvas.value.backgroundImage = undefined
     frontCanvas.value.requestRenderAll()
@@ -94,6 +95,7 @@ watch(() => frontState.value.backgroundSelection, async (newSelection) => {
 
 watch(() => backState.value.backgroundSelection, async (newSelection) => {
   if (!backCanvas.value || !newSelection) return
+  backCanvas.value.remove(...backCanvas.value.getObjects())
   if (newSelection === CUSTOM_BACKGROUND_SELECTION) {
     backCanvas.value.backgroundImage = undefined
     backCanvas.value.requestRenderAll()

--- a/stores/canvasStore.ts
+++ b/stores/canvasStore.ts
@@ -13,34 +13,50 @@ import { useCanvasControls } from '~/composables/useCanvasControls'
  * 
  * @example
  * const canvasStore = useCanvasStore()
- * canvasStore.save(canvas, canvasSize)
+ * canvasStore.save('front', canvas, canvasSize)
  * // ... later or on page reload ...
- * canvasStore.restore(canvas, currentCanvasSize)
+ * canvasStore.restore('front', canvas, currentCanvasSize)
  */
+
+export type CanvasSide = 'front' | 'back'
+
+interface CanvasSideState {
+  json: string | null
+  size: number
+  backgroundSelection: string | null
+  customBackgroundDataUrl: string | null
+}
+
+const createSideState = (): CanvasSideState => ({
+  json: null,
+  size: 0,
+  backgroundSelection: null,
+  customBackgroundDataUrl: null,
+})
 
 export const useCanvasStore = defineStore('canvas', {
   state: () => ({
-    json: null as string | null,
-    size: 0,
-    backgroundSelection: null as string | null,
-    customBackgroundDataUrl: null as string | null,
+    front: createSideState(),
+    back: createSideState(),
   }),
   actions: {
-    save(canvas: Canvas, size: number) {
-      this.json = JSON.stringify(canvas.toJSON())
-      this.size = size
+    save(side: CanvasSide, canvas: Canvas, size: number) {
+      const sideState = this[side] as CanvasSideState
+      sideState.json = JSON.stringify(canvas.toJSON())
+      sideState.size = size
     },
-    async restore(canvas: Canvas, currentSize: number) {
-      if (!this.json) return
+    async restore(side: CanvasSide, canvas: Canvas, currentSize: number) {
+      const sideState = this[side] as CanvasSideState
+      if (!sideState.json) return
 
       // Re-apply custom controls via reviver so each object is fixed immediately
       // as it is added during loadFromJSON — before any mouse events can fire.
       const { makeControlsReviver } = useCanvasControls()
-      await canvas.loadFromJSON(this.json, makeControlsReviver())
+      await canvas.loadFromJSON(sideState.json, makeControlsReviver())
 
       // Rescale objects and background if the canvas size changed since last save
-      if (this.size > 0 && this.size !== currentSize) {
-        const ratio = currentSize / this.size
+      if (sideState.size > 0 && sideState.size !== currentSize) {
+        const ratio = currentSize / sideState.size
         const { rescaleBackground, rescaleObjects } = useCanvasRescale()
         rescaleBackground(canvas, ratio)
         rescaleObjects(canvas, ratio)
@@ -48,17 +64,17 @@ export const useCanvasStore = defineStore('canvas', {
 
       canvas.requestRenderAll()
     },
-    setBackgroundSelection(selection: string | null) {
-      this.backgroundSelection = selection
+    setBackgroundSelection(side: CanvasSide, selection: string | null) {
+      const sideState = this[side] as CanvasSideState
+      sideState.backgroundSelection = selection
     },
-    setCustomBackgroundDataUrl(dataUrl: string | null) {
-      this.customBackgroundDataUrl = dataUrl
+    setCustomBackgroundDataUrl(side: CanvasSide, dataUrl: string | null) {
+      const sideState = this[side] as CanvasSideState
+      sideState.customBackgroundDataUrl = dataUrl
     },
     clear() {
-      this.json = null
-      this.size = 0
-      this.backgroundSelection = null
-      this.customBackgroundDataUrl = null
+      this.front = createSideState()
+      this.back = createSideState()
     }
   }
 })


### PR DESCRIPTION
## 📝 Description

* Added support for two canvas to store both front and back at the same time. 
* Added drop down for switch between front and back.
* Added functionality for export feature to export both front and back at the same time

Fixes #124

## 🔍 Type of change

- [x] New feature

## ✅ Checklist

- [x] Code follows project coding standards
- [x] All TypeScript types are properly defined
- [x] Components are properly documented
- [x] No console.logs in production code
- [x] Responsive design tested on all breakpoints
- [x] No ESLint errors or warnings
- [ ] No security audit errors or warnings
- [ ] Lighthouse performance is still ok

## 💡 Additional context

Add any other context about the PR here.
