### PR TITLE
#167 text warp improvement

### DIFF
--- a/components/features/TextboxControls.vue
+++ b/components/features/TextboxControls.vue
@@ -4,7 +4,7 @@
 // 1. Imports
 import { type Canvas, Textbox, ActiveSelection } from 'fabric'
 import { ref, shallowRef, computed, watch, onMounted, onUnmounted } from 'vue'
-import { setTextboxTextRadius, MAX_TEXT_RADIUS } from '~/utils/canvasUtils'
+import { setTextboxTextRadius, MIN_TEXT_RADIUS, MAX_TEXT_RADIUS } from '~/utils/canvasUtils'
 import { CircularTextbox } from '~/utils/circularTextbox'
 import BaseDropdown from '~/components/base/BaseDropdown.vue'
 import type { DropdownGroup } from '~/components/base/BaseDropdown.vue'
@@ -34,9 +34,29 @@ const isBold = ref(false)
 const isItalic = ref(false)
 const textAlign = ref<'left' | 'center' | 'right'>('left')
 const fill = ref('#000000')
-const textRadius = ref(0)
+// warpSlider: -100 to 100, where 0 = no warp, ±100 = maximum warp.
+// Positive = text curves upward (left side of arc), negative = downward (right side).
+const warpSlider = ref(0)
 const textValue = ref('')
 const circularMode = ref(false)
+
+// Maps slider intensity (0–100) → fabric radius (MAX → MIN, i.e. larger slider = tighter arc = more warp).
+function sliderToRadius(v: number): number {
+  if (v === 0) return 0
+  const sign = v > 0 ? 1 : -1
+  return sign * (MAX_TEXT_RADIUS - (Math.abs(v) / 100) * (MAX_TEXT_RADIUS - MIN_TEXT_RADIUS))
+}
+
+// Inverse of sliderToRadius: converts stored fabric radius back to slider intensity.
+function radiusToSlider(r: number): number {
+  if (r === 0) return 0
+  const absR = Math.abs(r)
+  if (absR < MIN_TEXT_RADIUS || absR > MAX_TEXT_RADIUS) return 0
+  const sign = r > 0 ? 1 : -1
+  const v = Math.round(((MAX_TEXT_RADIUS - absR) / (MAX_TEXT_RADIUS - MIN_TEXT_RADIUS)) * 100)
+  // Clamp to at least ±1 so an existing path isn't silently dropped
+  return sign * Math.max(v, 1)
+}
 
 let attachedCanvas: Canvas | null = null
 
@@ -137,7 +157,7 @@ function syncFromFirst() {
   textAlign.value = (first.textAlign as 'left' | 'center' | 'right') ?? 'left'
   fill.value = (first.fill as string) ?? '#000000'
   textValue.value = first.text ?? ''
-  textRadius.value = first instanceof CircularTextbox ? first.textRadius : 0
+  warpSlider.value = first instanceof CircularTextbox ? radiusToSlider(first.textRadius) : 0
 }
 
 function applyToAll(updater: (tb: Textbox) => void) {
@@ -204,7 +224,7 @@ function closeCircularMode() {
 function applyCircularRadius() {
   applyToAll((tb) => {
     if (tb instanceof CircularTextbox) {
-      setTextboxTextRadius(tb, textRadius.value)
+      setTextboxTextRadius(tb, sliderToRadius(warpSlider.value))
     }
   })
 }
@@ -243,15 +263,18 @@ watch(() => props.canvas, (newCanvas, oldCanvas) => {
       <label class="flex-1 flex flex-col gap-2">
         <span class="text-sm font-medium text-gray-700">Cirkulär textradie</span>
         <input
-          v-model.number="textRadius"
+          v-model.number="warpSlider"
           type="range"
-          :min="-MAX_TEXT_RADIUS"
-          :max="MAX_TEXT_RADIUS"
+          min="-100"
+          max="100"
+          step="1"
           class="h-2 bg-gray-300 rounded-lg appearance-none cursor-pointer accent-blue-500"
           @input="applyCircularRadius"
           @change="applyCircularRadius"
         >
-        <span class="text-xs text-gray-600">{{ textRadius }}px</span>
+        <span class="text-xs text-gray-600">
+          {{ warpSlider === 0 ? 'Ingen böjning' : (warpSlider > 0 ? `${warpSlider}%` : `${Math.abs(warpSlider)}%`) }}
+        </span>
       </label>
       <button
         type="button"

--- a/components/features/TextboxControls.vue
+++ b/components/features/TextboxControls.vue
@@ -269,7 +269,7 @@ watch(() => props.canvas, (newCanvas, oldCanvas) => {
     <!-- Circular Text Mode -->
     <div v-if="circularMode" class="flex items-center gap-3 p-3 sm:p-2 bg-white border border-gray-300 rounded-lg shadow-md">
       <label class="flex-1 flex flex-col gap-2">
-        <span class="text-sm font-medium text-gray-700">Cirkulär textradie</span>
+        <span class="text-sm font-medium text-gray-700">Böjning</span>
         <input
           v-model.number="warpSlider"
           type="range"
@@ -281,7 +281,7 @@ watch(() => props.canvas, (newCanvas, oldCanvas) => {
           @change="applyCircularRadius"
         >
         <span class="text-xs text-gray-600">
-          {{ warpSlider === 0 ? 'Ingen böjning' : (warpSlider > 0 ? `${warpSlider}%` : `${Math.abs(warpSlider)}%`) }}
+          {{ warpSlider === 0 ? 'Ingen böjning' : `${warpSlider}%` }}
         </span>
       </label>
       <button

--- a/components/features/TextboxControls.vue
+++ b/components/features/TextboxControls.vue
@@ -44,7 +44,10 @@ const circularMode = ref(false)
 function sliderToRadius(v: number): number {
   if (v === 0) return 0
   const sign = v > 0 ? 1 : -1
-  return sign * (MAX_TEXT_RADIUS - (Math.abs(v) / 100) * (MAX_TEXT_RADIUS - MIN_TEXT_RADIUS))
+  if (Math.abs(v) < 20) {
+    return sign * (MAX_TEXT_RADIUS - 5 * ((Math.abs(v)-1) / 100) * (MAX_TEXT_RADIUS - MIN_TEXT_RADIUS))
+  }
+  return sign * (MAX_TEXT_RADIUS/10 - (Math.abs(v) / 100) * (MAX_TEXT_RADIUS/10 - MIN_TEXT_RADIUS))
 }
 
 // Inverse of sliderToRadius: converts stored fabric radius back to slider intensity.
@@ -53,7 +56,12 @@ function radiusToSlider(r: number): number {
   const absR = Math.abs(r)
   if (absR < MIN_TEXT_RADIUS || absR > MAX_TEXT_RADIUS) return 0
   const sign = r > 0 ? 1 : -1
-  const v = Math.round(((MAX_TEXT_RADIUS - absR) / (MAX_TEXT_RADIUS - MIN_TEXT_RADIUS)) * 100)
+  if (absR > MAX_TEXT_RADIUS/10) {
+    const v = Math.round(((MAX_TEXT_RADIUS - absR) / (5 * (MAX_TEXT_RADIUS - MIN_TEXT_RADIUS))) * 100) + 1
+    // Clamp to at least ±1 so an existing path isn't silently dropped
+    return sign * Math.max(v, 1)
+  }
+  const v = Math.round(((MAX_TEXT_RADIUS/10 - absR) / (MAX_TEXT_RADIUS/10 - MIN_TEXT_RADIUS)) * 100)
   // Clamp to at least ±1 so an existing path isn't silently dropped
   return sign * Math.max(v, 1)
 }

--- a/utils/canvasUtils.ts
+++ b/utils/canvasUtils.ts
@@ -5,12 +5,12 @@
  */
 import type { FabricObject, Canvas, FabricImage } from 'fabric'
 import type { CircularTextbox } from './circularTextbox'
-import { Path } from 'fabric'
+import { Path, Point } from 'fabric'
 import { CUSTOM_BACKGROUND_ID } from '~/composables/useCustomBackground'
 
 // Valid range for text radius to create a circular path
 export const MIN_TEXT_RADIUS = 25
-export const MAX_TEXT_RADIUS = 100
+export const MAX_TEXT_RADIUS = 300
 
 /**
  * Toggles the z-order of a single Fabric object.
@@ -56,13 +56,17 @@ function createCircularTextPath(radius: number) : Path {
   const absRadius = Math.abs(radius)
   if(hasPath(radius)) {
     // Create a circle path centered at origin (0, 0), rotated 90 degrees
-    return new Path(
+    const path = new Path(
         `M 0 ${radius} 
         A ${absRadius} ${absRadius} 0 1 1 0  ${-radius} 
         A ${absRadius} ${absRadius} 0 1 1 0  ${radius} 
         Z`,
-        { offset: { x: 0, y: radius }, fill: '', stroke: 'blue', strokeWidth: 1, strokeDashArray: [5, 5], visible: false }
+        { fill: '', stroke: 'blue', strokeWidth: 1, strokeDashArray: [5, 5], visible: false }
       );
+    // Anchor the text path to the tangent point instead of the circle center.
+    // This keeps the curved text closer to the original text position.
+    path.pathOffset = new Point(0, -radius - 10)
+    return path
   } else {
     return undefined as unknown as Path; // Return undefined if radius is out of bounds, but cast to Path to satisfy return type
   }
@@ -80,15 +84,33 @@ function createCircularTextPath(radius: number) : Path {
  * @param radius - The desired text radius, which determines the circular path
  */
 export function setTextboxTextRadius(textbox: CircularTextbox, radius: number): void {
-  const circumference = 2 * Math.PI * Math.abs(radius)
+  const center = textbox.getCenterPoint()
+  const nextHasPath = hasPath(radius)
+  const currentHasPath = hasPath(textbox.textRadius)
+
+  if (!textbox.baseWidth || textbox.baseWidth <= 0) {
+    textbox.baseWidth = textbox.width
+  }
+
+  if (!currentHasPath) {
+    textbox.baseWidth = textbox.width
+  }
+
   textbox.set({
-    width: hasPath(radius) ? circumference : textbox.width, // Update width based on whether text is on a path
+    width: textbox.baseWidth,
     textRadius: radius,
-    path: createCircularTextPath(radius),
+    path: nextHasPath ? createCircularTextPath(radius) : undefined,
     pathSide: radius >= 0 ? 'left' : 'right',
     pathStartOffset: 0,
   })
-  textbox.controls.resize.visible = !hasPath(radius)
+
+  if (!nextHasPath) {
+    textbox.set('width', textbox.baseWidth)
+  }
+
+  textbox.initDimensions()
+  textbox.controls.resize.visible = !nextHasPath
+  textbox.setPositionByOrigin(center, 'center', 'center')
   textbox.setCoords()
 }
 

--- a/utils/canvasUtils.ts
+++ b/utils/canvasUtils.ts
@@ -10,7 +10,7 @@ import { CUSTOM_BACKGROUND_ID } from '~/composables/useCustomBackground'
 
 // Valid range for text radius to create a circular path
 export const MIN_TEXT_RADIUS = 25
-export const MAX_TEXT_RADIUS = 300
+export const MAX_TEXT_RADIUS = 3000
 
 const BASELINE_PATH_OFFSET_Y = -10
 const ASCENDER_PATH_OFFSET_Y = 18

--- a/utils/canvasUtils.ts
+++ b/utils/canvasUtils.ts
@@ -12,6 +12,9 @@ import { CUSTOM_BACKGROUND_ID } from '~/composables/useCustomBackground'
 export const MIN_TEXT_RADIUS = 25
 export const MAX_TEXT_RADIUS = 300
 
+const BASELINE_PATH_OFFSET_Y = -10
+const ASCENDER_PATH_OFFSET_Y = 18
+
 /**
  * Toggles the z-order of a single Fabric object.
  * If the object is at the front, sends it to the back. Otherwise, brings it to the front.
@@ -52,7 +55,21 @@ function hasPath(radius: number): boolean {
  * 
  * @param radius - The radius of the circular path
  */
-function createCircularTextPath(radius: number) : Path {
+function getCircularTextPathAlign(radius: number): 'baseline' | 'center' | 'ascender' | 'descender' {
+  // Upward warps need the path to sit above the glyphs instead of below them,
+  // otherwise the letters collapse into the inside of the arc too quickly.
+  return radius < 0 ? 'ascender' : 'baseline'
+}
+
+function getCircularTextPathOffset(radius: number, pathAlign: 'baseline' | 'center' | 'ascender' | 'descender'): Point {
+  const offsetY = pathAlign === 'ascender'
+    ? -radius + ASCENDER_PATH_OFFSET_Y
+    : -radius + BASELINE_PATH_OFFSET_Y
+
+  return new Point(0, offsetY)
+}
+
+function createCircularTextPath(radius: number, pathAlign: 'baseline' | 'center' | 'ascender' | 'descender') : Path {
   const absRadius = Math.abs(radius)
   if(hasPath(radius)) {
     // Create a circle path centered at origin (0, 0), rotated 90 degrees
@@ -65,7 +82,7 @@ function createCircularTextPath(radius: number) : Path {
       );
     // Anchor the text path to the tangent point instead of the circle center.
     // This keeps the curved text closer to the original text position.
-    path.pathOffset = new Point(0, -radius - 10)
+    path.pathOffset = getCircularTextPathOffset(radius, pathAlign)
     return path
   } else {
     return undefined as unknown as Path; // Return undefined if radius is out of bounds, but cast to Path to satisfy return type
@@ -87,6 +104,7 @@ export function setTextboxTextRadius(textbox: CircularTextbox, radius: number): 
   const center = textbox.getCenterPoint()
   const nextHasPath = hasPath(radius)
   const currentHasPath = hasPath(textbox.textRadius)
+  const pathAlign = getCircularTextPathAlign(radius)
 
   if (!textbox.baseWidth || textbox.baseWidth <= 0) {
     textbox.baseWidth = textbox.width
@@ -99,9 +117,11 @@ export function setTextboxTextRadius(textbox: CircularTextbox, radius: number): 
   textbox.set({
     width: textbox.baseWidth,
     textRadius: radius,
-    path: nextHasPath ? createCircularTextPath(radius) : undefined,
+    path: nextHasPath ? createCircularTextPath(radius, pathAlign) : undefined,
     pathSide: radius >= 0 ? 'left' : 'right',
+    pathAlign,
     pathStartOffset: 0,
+    objectCaching: !nextHasPath,
   })
 
   if (!nextHasPath) {

--- a/utils/circularTextbox.ts
+++ b/utils/circularTextbox.ts
@@ -10,6 +10,7 @@ import type { SerializedTextboxProps } from 'fabric'
  */
 export interface SerializedCircularTextboxProps extends SerializedTextboxProps {
   textRadius: number
+  baseWidth: number
 }
 
 /**
@@ -29,8 +30,12 @@ export class CircularTextbox extends Textbox {
   /** Radius of the circular text path. 0 means no path (normal text layout). */
   declare textRadius: number
 
+  /** Width to use for textbox layout independently of the circular path radius. */
+  declare baseWidth: number
+
   static override ownDefaults = {
     textRadius: 0,
+    baseWidth: 0,
   }
 
   static override getDefaults(): Record<string, unknown> {
@@ -49,7 +54,7 @@ export class CircularTextbox extends Textbox {
   // @ts-expect-error: see comment above — Fabric generic constraint prevents clean override
   override toObject(propertiesToInclude: string[] = []): SerializedCircularTextboxProps {
     const base = super.toObject(propertiesToInclude as never) as SerializedTextboxProps
-    return { ...base, textRadius: this.textRadius }
+    return { ...base, textRadius: this.textRadius, baseWidth: this.baseWidth }
   }
 
   /**


### PR DESCRIPTION
## 📝 Description

* Changed the slider to start with maximum radius and go lower further out on the slider. 
* Improved the maximum radius of the warped text. 
* Added an offset to the textboxt to counteract the text not being centered

Fixes #167 

## 🔍 Type of change

- [x] New feature

## ✅ Checklist

- [x] Code follows project coding standards
- [x] All TypeScript types are properly defined
- [x] Components are properly documented
- [x] No console.logs in production code
- [x] Responsive design tested on all breakpoints
- [x] No ESLint errors or warnings
- [ ] No security audit errors or warnings
- [ ] Lighthouse performance is still ok

## 💡 Additional context

Add any other context about the PR here.
