### PR TITLE
185 Look into SVG usage with fabric.js

### DIFF
--- a/components/features/QuoteForm.vue
+++ b/components/features/QuoteForm.vue
@@ -159,9 +159,11 @@ async function collectQuoteFiles(): Promise<File[]> {
       collected.push(await dataUrlToFile(compressedMerged, `design-${id}-side-${sanitizeFilenameSegment(activeSideLabels.value[entry.index]?.label ?? String(entry.index))}.jpg`))
       if (++imgCount >= MAX_IMAGE_COUNT) break;
 
-      // Individual layers: keep as PNG to preserve transparency
+      // Individual layers: preserve original format (SVG stays SVG, rasters stay PNG).
       for (let i = 0; i < imageUrls.length; i++) {
-        collected.push(await dataUrlToFile(imageUrls[i], `design-${id}-side-${sanitizeFilenameSegment(activeSideLabels.value[entry.index]?.label ?? String(entry.index))}-layer-${i + 1}.png`))
+        const layer = imageUrls[i]
+        const ext = layer.mimeType === 'image/svg+xml' ? 'svg' : 'png'
+        collected.push(await dataUrlToFile(layer.url, `design-${id}-side-${sanitizeFilenameSegment(activeSideLabels.value[entry.index]?.label ?? String(entry.index))}-layer-${i + 1}.${ext}`))
         if (++imgCount >= MAX_IMAGE_COUNT) break;
       }
     }

--- a/composables/useCanvasControls.ts
+++ b/composables/useCanvasControls.ts
@@ -4,7 +4,7 @@ import { FabricImage, Textbox } from 'fabric'
 import type { Canvas, FabricObject } from 'fabric'
 import { CircularTextbox } from '~/utils/circularTextbox'
 import { setTextboxTextRadius } from '~/utils/canvasUtils'
-import { useCustomImage } from '~/composables/useCustomImage'
+import { useCustomImage, attachSvgDataUrl } from '~/composables/useCustomImage'
 import { useCustomText } from '~/composables/useCustomText'
 
 /**
@@ -47,8 +47,15 @@ export function useCanvasControls() {
    * Fixes controls on each object as it is added, before any mouse events can fire.
    */
   function makeControlsReviver() {
-    return (_data: Record<string, unknown>, obj: unknown): void => {
-      if (obj instanceof FabricImage || obj instanceof Textbox) {
+    return (data: Record<string, unknown>, obj: unknown): void => {
+      if (obj instanceof FabricImage) {
+        reapplyControlsToObject(obj)
+        // Re-attach the SVG source URL (and toObject override) so it survives
+        // future save/restore cycles after a canvas side switch.
+        if (typeof data.svgDataUrl === 'string') {
+          attachSvgDataUrl(obj, data.svgDataUrl)
+        }
+      } else if (obj instanceof Textbox) {
         reapplyControlsToObject(obj)
       }
     }

--- a/composables/useCanvasExport.ts
+++ b/composables/useCanvasExport.ts
@@ -12,18 +12,84 @@ export interface ExportedLayer {
  * size on the canvas. The viewBox is preserved so the vector scales correctly;
  * only the outer dimensions (which control the file's intrinsic size) are updated.
  *
+ * When a rotation angle is provided the visual content is wrapped in a <g>
+ * element with the corresponding transform, and the outer bounding box is
+ * expanded so the rotated content is fully visible with no clipping.
+ *
  * This ensures every exported SVG has a consistent, meaningful size instead of
  * reflecting the original file's arbitrary viewBox dimensions.
  */
-function stampSvgExportSize(svgDataUrl: string, width: number, height: number): string {
+function stampSvgExportSize(svgDataUrl: string, width: number, height: number, angle: number): string {
   const svgText = decodeURIComponent(
     svgDataUrl.replace('data:image/svg+xml;charset=utf-8,', '')
   )
   const parser = new DOMParser()
   const doc = parser.parseFromString(svgText, 'image/svg+xml')
   const svgEl = doc.documentElement
-  svgEl.setAttribute('width', String(Math.round(width)))
-  svgEl.setAttribute('height', String(Math.round(height)))
+
+  const roundedWidth = Math.round(width)
+  const roundedHeight = Math.round(height)
+
+  // Resolve the SVG's internal coordinate space from the viewBox attribute.
+  // Falls back to the stamped pixel dimensions if no viewBox is present.
+  const viewBoxAttr = svgEl.getAttribute('viewBox')
+  let vW: number
+  let vH: number
+  if (viewBoxAttr) {
+    const parts = viewBoxAttr.trim().split(/[\s,]+/)
+    vW = parseFloat(parts[2])
+    vH = parseFloat(parts[3])
+  } else {
+    vW = roundedWidth
+    vH = roundedHeight
+  }
+
+  // Normalise to [0, 360) so the angle === 0 short-circuit is reliable.
+  const normalisedAngle = ((angle % 360) + 360) % 360
+
+  if (normalisedAngle === 0) {
+    svgEl.setAttribute('width', String(roundedWidth))
+    svgEl.setAttribute('height', String(roundedHeight))
+    return new XMLSerializer().serializeToString(svgEl)
+  }
+
+  const θ = (angle * Math.PI) / 180
+  const abscos = Math.abs(Math.cos(θ))
+  const abssin = Math.abs(Math.sin(θ))
+
+  // New bounding box in SVG user units after rotation.
+  const newVW = vW * abscos + vH * abssin
+  const newVH = vW * abssin + vH * abscos
+
+  // Physical pixel dimensions of the rotated bounding box.
+  const scale = roundedWidth / vW
+  const newWidth = Math.round(newVW * scale)
+  const newHeight = Math.round(newVH * scale)
+
+  // Translation to keep the rotated content centred in the expanded viewBox.
+  const tx = (newVW - vW) / 2
+  const ty = (newVH - vH) / 2
+
+  // Structural elements must stay at root level so any <defs> references
+  // (gradients, clip-paths, filters) remain resolvable.
+  const KEEP_AT_ROOT = new Set(['defs', 'style', 'title', 'desc', 'metadata'])
+  const g = doc.createElementNS('http://www.w3.org/2000/svg', 'g')
+  // Rotate around the centre of the original content, then translate into the
+  // new (larger) bounding box so nothing is clipped.
+  g.setAttribute('transform', `translate(${tx} ${ty}) rotate(${angle} ${vW / 2} ${vH / 2})`)
+
+  const toMove = Array.from(svgEl.childNodes).filter(
+    node => !(node.nodeType === 1 && KEEP_AT_ROOT.has((node as Element).tagName.toLowerCase()))
+  )
+  for (const child of toMove) {
+    g.appendChild(child)
+  }
+  svgEl.appendChild(g)
+
+  svgEl.setAttribute('viewBox', `0 0 ${newVW} ${newVH}`)
+  svgEl.setAttribute('width', String(newWidth))
+  svgEl.setAttribute('height', String(newHeight))
+
   return new XMLSerializer().serializeToString(svgEl)
 }
 
@@ -56,9 +122,9 @@ export function useCanvasExport() {
         const svgDataUrl = (obj as FabricImage & { svgDataUrl?: string }).svgDataUrl
 
         if (svgDataUrl) {
-          // Stamp the canvas-rendered dimensions onto the SVG so the exported
-          // file reflects the actual size as placed in the design.
-          const svgText = stampSvgExportSize(svgDataUrl, obj.getScaledWidth(), obj.getScaledHeight())
+          // Stamp the canvas-rendered dimensions and rotation onto the SVG so
+          // the exported file reflects the actual size and orientation as placed in the design.
+          const svgText = stampSvgExportSize(svgDataUrl, obj.getScaledWidth(), obj.getScaledHeight(), obj.angle)
           const blob = new Blob([svgText], { type: 'image/svg+xml' })
           return { url: URL.createObjectURL(blob), mimeType: 'image/svg+xml' }
         }

--- a/composables/useCanvasExport.ts
+++ b/composables/useCanvasExport.ts
@@ -2,6 +2,11 @@
 import type { Canvas } from 'fabric'
 import { FabricImage } from 'fabric'
 
+export interface ExportedLayer {
+  url: string
+  mimeType: 'image/png' | 'image/svg+xml'
+}
+
 export function useCanvasExport() {
   async function exportMergedImage(canvas: Canvas): Promise<string> {
     const htmlCanvas = canvas.getElement() as HTMLCanvasElement
@@ -21,25 +26,39 @@ export function useCanvasExport() {
     return canvas.toDataURL({ format: 'png', multiplier: 1 })
   }
 
-  async function exportImageObjects(canvas: Canvas): Promise<string[]> {
+  async function exportImageObjects(canvas: Canvas): Promise<ExportedLayer[]> {
     const imageObjects = canvas
       .getObjects()
       .filter(obj => obj instanceof FabricImage) as FabricImage[]
 
     return Promise.all(
-      imageObjects.map(obj => {
-        const objCanvas = obj.toCanvasElement()
+      imageObjects.map(async (obj): Promise<ExportedLayer> => {
+        const svgDataUrl = (obj as FabricImage & { svgDataUrl?: string }).svgDataUrl
 
+        if (svgDataUrl) {
+          // Return the original vector SVG instead of rasterising it.
+          // Decode the percent-encoded data URL back to SVG text and wrap
+          // in a blob so the QuoteForm pipeline handles it uniformly.
+          const svgText = decodeURIComponent(
+            svgDataUrl.replace('data:image/svg+xml;charset=utf-8,', '')
+          )
+          const blob = new Blob([svgText], { type: 'image/svg+xml' })
+          return { url: URL.createObjectURL(blob), mimeType: 'image/svg+xml' }
+        }
+
+        // Raster images: render to an offscreen canvas and export as PNG.
+        const objCanvas = obj.toCanvasElement()
         if (typeof objCanvas.toBlob === 'function') {
-          return new Promise<string>((resolve, reject) => {
+          const url = await new Promise<string>((resolve, reject) => {
             objCanvas.toBlob((blob) => {
               if (!blob) return reject(new Error('toBlob returned null'))
               resolve(URL.createObjectURL(blob))
             }, 'image/png')
           })
+          return { url, mimeType: 'image/png' }
         }
 
-        return Promise.resolve(objCanvas.toDataURL('image/png'))
+        return { url: objCanvas.toDataURL('image/png'), mimeType: 'image/png' }
       })
     )
   }

--- a/composables/useCanvasExport.ts
+++ b/composables/useCanvasExport.ts
@@ -13,8 +13,9 @@ export interface ExportedLayer {
  * only the outer dimensions (which control the file's intrinsic size) are updated.
  *
  * When a rotation angle is provided the visual content is wrapped in a <g>
- * element with the corresponding transform, and the outer bounding box is
- * expanded so the rotated content is fully visible with no clipping.
+ * element with a rotate transform around the true centre of the viewBox
+ * coordinate space. The viewBox is expanded symmetrically around that centre
+ * so the rotated content is fully visible with no clipping.
  *
  * This ensures every exported SVG has a consistent, meaningful size instead of
  * reflecting the original file's arbitrary viewBox dimensions.
@@ -30,18 +31,18 @@ function stampSvgExportSize(svgDataUrl: string, width: number, height: number, a
   const roundedWidth = Math.round(width)
   const roundedHeight = Math.round(height)
 
-  // Resolve the SVG's internal coordinate space from the viewBox attribute.
-  // Falls back to the stamped pixel dimensions if no viewBox is present.
+  // Read all four viewBox components — including minX/minY which may be
+  // non-zero (e.g. Google Material icons use viewBox="0 -960 960 960").
   const viewBoxAttr = svgEl.getAttribute('viewBox')
-  let vW: number
-  let vH: number
+  let minX: number, minY: number, vW: number, vH: number
   if (viewBoxAttr) {
     const parts = viewBoxAttr.trim().split(/[\s,]+/)
-    vW = parseFloat(parts[2])
-    vH = parseFloat(parts[3])
+    minX = parseFloat(parts[0])
+    minY = parseFloat(parts[1])
+    vW   = parseFloat(parts[2])
+    vH   = parseFloat(parts[3])
   } else {
-    vW = roundedWidth
-    vH = roundedHeight
+    minX = 0; minY = 0; vW = roundedWidth; vH = roundedHeight
   }
 
   // Normalise to [0, 360) so the angle === 0 short-circuit is reliable.
@@ -53,30 +54,29 @@ function stampSvgExportSize(svgDataUrl: string, width: number, height: number, a
     return new XMLSerializer().serializeToString(svgEl)
   }
 
+  // True centre of the viewBox coordinate space.
+  const cx = minX + vW / 2
+  const cy = minY + vH / 2
+
   const θ = (angle * Math.PI) / 180
   const abscos = Math.abs(Math.cos(θ))
   const abssin = Math.abs(Math.sin(θ))
 
-  // New bounding box in SVG user units after rotation.
+  // New bounding box in SVG user units after rotation around (cx, cy).
   const newVW = vW * abscos + vH * abssin
   const newVH = vW * abssin + vH * abscos
 
-  // Physical pixel dimensions of the rotated bounding box.
+  // Physical pixel dimensions — maintain the same pixel-per-unit scale.
   const scale = roundedWidth / vW
-  const newWidth = Math.round(newVW * scale)
+  const newWidth  = Math.round(newVW * scale)
   const newHeight = Math.round(newVH * scale)
 
-  // Translation to keep the rotated content centred in the expanded viewBox.
-  const tx = (newVW - vW) / 2
-  const ty = (newVH - vH) / 2
-
-  // Structural elements must stay at root level so any <defs> references
-  // (gradients, clip-paths, filters) remain resolvable.
+  // Wrap visual content in a pure rotation transform (no translate needed —
+  // the viewBox update below absorbs the offset). Structural elements
+  // (<defs>, <style>, etc.) stay at root so their references keep resolving.
   const KEEP_AT_ROOT = new Set(['defs', 'style', 'title', 'desc', 'metadata'])
   const g = doc.createElementNS('http://www.w3.org/2000/svg', 'g')
-  // Rotate around the centre of the original content, then translate into the
-  // new (larger) bounding box so nothing is clipped.
-  g.setAttribute('transform', `translate(${tx} ${ty}) rotate(${angle} ${vW / 2} ${vH / 2})`)
+  g.setAttribute('transform', `rotate(${angle} ${cx} ${cy})`)
 
   const toMove = Array.from(svgEl.childNodes).filter(
     node => !(node.nodeType === 1 && KEEP_AT_ROOT.has((node as Element).tagName.toLowerCase()))
@@ -86,7 +86,9 @@ function stampSvgExportSize(svgDataUrl: string, width: number, height: number, a
   }
   svgEl.appendChild(g)
 
-  svgEl.setAttribute('viewBox', `0 0 ${newVW} ${newVH}`)
+  // Expand the viewBox symmetrically around the same centre so the rotated
+  // content is fully visible without any extra translation.
+  svgEl.setAttribute('viewBox', `${cx - newVW / 2} ${cy - newVH / 2} ${newVW} ${newVH}`)
   svgEl.setAttribute('width', String(newWidth))
   svgEl.setAttribute('height', String(newHeight))
 

--- a/composables/useCanvasExport.ts
+++ b/composables/useCanvasExport.ts
@@ -7,6 +7,26 @@ export interface ExportedLayer {
   mimeType: 'image/png' | 'image/svg+xml'
 }
 
+/**
+ * Stamps the exported SVG's width/height to match the object's actual rendered
+ * size on the canvas. The viewBox is preserved so the vector scales correctly;
+ * only the outer dimensions (which control the file's intrinsic size) are updated.
+ *
+ * This ensures every exported SVG has a consistent, meaningful size instead of
+ * reflecting the original file's arbitrary viewBox dimensions.
+ */
+function stampSvgExportSize(svgDataUrl: string, width: number, height: number): string {
+  const svgText = decodeURIComponent(
+    svgDataUrl.replace('data:image/svg+xml;charset=utf-8,', '')
+  )
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(svgText, 'image/svg+xml')
+  const svgEl = doc.documentElement
+  svgEl.setAttribute('width', String(Math.round(width)))
+  svgEl.setAttribute('height', String(Math.round(height)))
+  return new XMLSerializer().serializeToString(svgEl)
+}
+
 export function useCanvasExport() {
   async function exportMergedImage(canvas: Canvas): Promise<string> {
     const htmlCanvas = canvas.getElement() as HTMLCanvasElement
@@ -36,12 +56,9 @@ export function useCanvasExport() {
         const svgDataUrl = (obj as FabricImage & { svgDataUrl?: string }).svgDataUrl
 
         if (svgDataUrl) {
-          // Return the original vector SVG instead of rasterising it.
-          // Decode the percent-encoded data URL back to SVG text and wrap
-          // in a blob so the QuoteForm pipeline handles it uniformly.
-          const svgText = decodeURIComponent(
-            svgDataUrl.replace('data:image/svg+xml;charset=utf-8,', '')
-          )
+          // Stamp the canvas-rendered dimensions onto the SVG so the exported
+          // file reflects the actual size as placed in the design.
+          const svgText = stampSvgExportSize(svgDataUrl, obj.getScaledWidth(), obj.getScaledHeight())
           const blob = new Blob([svgText], { type: 'image/svg+xml' })
           return { url: URL.createObjectURL(blob), mimeType: 'image/svg+xml' }
         }

--- a/composables/useCustomImage.ts
+++ b/composables/useCustomImage.ts
@@ -15,6 +15,29 @@ interface Transform {
   target?: unknown
 }
 
+/** FabricImage extended with an optional persisted SVG source URL. */
+type FabricImageWithSvg = FabricImage & { svgDataUrl?: string }
+
+/**
+ * Attach the original SVG data URL to a FabricImage so it can be recovered
+ * at export time and survives canvas save / restore round-trips.
+ *
+ * Overrides `toObject` on the specific instance so that `canvas.toJSON()`
+ * includes `svgDataUrl` in the serialized output without needing to touch
+ * `canvas.toJSON(['svgDataUrl'])` at the call site.
+ */
+export function attachSvgDataUrl(image: FabricImage, svgDataUrl: string): void {
+  const imgWithSvg = image as FabricImageWithSvg
+  imgWithSvg.svgDataUrl = svgDataUrl
+
+  // Cast through unknown to avoid Fabric v6's overly complex generic signature on toObject.
+  const originalToObject = (image.toObject as (props?: string[]) => Record<string, unknown>).bind(image)
+  ;(image as { toObject: (props?: string[]) => Record<string, unknown> }).toObject = (propertiesToInclude?: string[]) => ({
+    ...originalToObject(propertiesToInclude),
+    svgDataUrl,
+  })
+}
+
 /**
  * SVGs without explicit width/height attributes (only viewBox) render at 0×0
  * in Fabric.js, causing mispositioned or invisible objects. This normalizes
@@ -190,12 +213,19 @@ export function useCustomImage() {
     try {
       // SVGs without explicit width/height must be normalised first so Fabric.js
       // can determine natural dimensions and centre the object correctly.
-      const dataUrl = file.type === 'image/svg+xml'
+      const isSvg = file.type === 'image/svg+xml'
+      const dataUrl = isSvg
         ? await readSvgAsDataUrl(file)
         : await readFileAsDataUrl(file)
 
       // Load the image using Fabric.js
       const image = await FabricImage.fromURL(dataUrl)
+
+      // For SVGs, attach the source data URL so the export pipeline can
+      // return the original vector instead of a rasterised PNG.
+      if (isSvg) {
+        attachSvgDataUrl(image, dataUrl)
+      }
 
       // Apply custom controls and styling
       applyImageControls(image)

--- a/composables/useCustomImage.ts
+++ b/composables/useCustomImage.ts
@@ -15,6 +15,65 @@ interface Transform {
   target?: unknown
 }
 
+/**
+ * SVGs without explicit width/height attributes (only viewBox) render at 0×0
+ * in Fabric.js, causing mispositioned or invisible objects. This normalizes
+ * the SVG by injecting dimensions derived from the viewBox before loading.
+ */
+function normalizeSvgDimensions(svgText: string): string {
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(svgText, 'image/svg+xml')
+  const svgEl = doc.documentElement
+
+  if (!svgEl.hasAttribute('width') || !svgEl.hasAttribute('height')) {
+    const viewBox = svgEl.getAttribute('viewBox')
+    if (viewBox) {
+      const parts = viewBox.trim().split(/[\s,]+/)
+      if (parts.length === 4) {
+        const w = parseFloat(parts[2])
+        const h = parseFloat(parts[3])
+        if (!isNaN(w) && !isNaN(h)) {
+          if (!svgEl.hasAttribute('width')) svgEl.setAttribute('width', String(w))
+          if (!svgEl.hasAttribute('height')) svgEl.setAttribute('height', String(h))
+        }
+      }
+    }
+  }
+
+  const serializer = new XMLSerializer()
+  const fixedSvg = serializer.serializeToString(svgEl)
+  return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(fixedSvg)}`
+}
+
+function readFileAsDataUrl(file: File): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = (e) => {
+      const result = e.target?.result
+      if (typeof result === 'string') resolve(result)
+      else reject(new Error('Failed to read file as data URL'))
+    }
+    reader.onerror = () => reject(new Error('File reading error'))
+    reader.readAsDataURL(file)
+  })
+}
+
+function readSvgAsDataUrl(file: File): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = (e) => {
+      const result = e.target?.result
+      if (typeof result !== 'string') {
+        reject(new Error('Failed to read SVG file'))
+        return
+      }
+      resolve(normalizeSvgDimensions(result))
+    }
+    reader.onerror = () => reject(new Error('File reading error'))
+    reader.readAsText(file)
+  })
+}
+
 
 
 export function useCustomImage() {
@@ -119,21 +178,11 @@ export function useCustomImage() {
     }
 
     try {
-      // Read the file as a data URL
-      const reader = new FileReader()
-
-      const dataUrl = await new Promise<string>((resolve, reject) => {
-        reader.onload = (e) => {
-          const result = e.target?.result
-          if (typeof result === 'string') {
-            resolve(result)
-          } else {
-            reject(new Error('Failed to read file as data URL'))
-          }
-        }
-        reader.onerror = () => reject(new Error('File reading error'))
-        reader.readAsDataURL(file)
-      })
+      // SVGs without explicit width/height must be normalised first so Fabric.js
+      // can determine natural dimensions and centre the object correctly.
+      const dataUrl = file.type === 'image/svg+xml'
+        ? await readSvgAsDataUrl(file)
+        : await readFileAsDataUrl(file)
 
       // Load the image using Fabric.js
       const image = await FabricImage.fromURL(dataUrl)

--- a/composables/useCustomImage.ts
+++ b/composables/useCustomImage.ts
@@ -45,6 +45,10 @@ function normalizeSvgDimensions(svgText: string): string {
   return `data:image/svg+xml;charset=utf-8,${encodeURIComponent(fixedSvg)}`
 }
 
+/**
+ * Reads a file and resolves with a base64-encoded data URL.
+ * Used for raster image formats (PNG, JPEG, WebP, GIF).
+ */
 function readFileAsDataUrl(file: File): Promise<string> {
   return new Promise<string>((resolve, reject) => {
     const reader = new FileReader()
@@ -58,6 +62,12 @@ function readFileAsDataUrl(file: File): Promise<string> {
   })
 }
 
+/**
+ * Reads an SVG file as text, normalises its dimensions, and resolves with
+ * a percent-encoded `data:image/svg+xml` URL ready for Fabric.js.
+ * Reading as text (instead of a base64 data URL) is required so the SVG
+ * markup can be parsed and patched by normalizeSvgDimensions.
+ */
 function readSvgAsDataUrl(file: File): Promise<string> {
   return new Promise<string>((resolve, reject) => {
     const reader = new FileReader()

--- a/composables/useQuoteForm.ts
+++ b/composables/useQuoteForm.ts
@@ -18,7 +18,7 @@ const MAX_FILE_SIZE = 7 * 1024 * 1024
 export const MAX_IMAGE_COUNT = 16
 
 /** Allowed image MIME types */
-const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp', 'image/gif']
+const ALLOWED_IMAGE_TYPES = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp', 'image/gif', 'image/svg+xml']
 
 // ===== ZOD SCHEMA =====
 /** Quote form validation schema */
@@ -76,7 +76,7 @@ export const quoteFormSchema = z.object({
       if (file.size > MAX_FILE_SIZE) return false
       return ALLOWED_IMAGE_TYPES.includes(file.type)
     }, {
-      message: 'Bilden måste vara mindre än 7MB och i formatet JPEG, PNG, WebP eller GIF',
+      message: 'Bilden måste vara mindre än 7MB och i formatet JPEG, PNG, WebP, GIF eller SVG',
     }))
     .max(MAX_IMAGE_COUNT, { message: `Maximalt ${MAX_IMAGE_COUNT} bilder kan bifogas` })
     .optional()


### PR DESCRIPTION
## 📝 Description

* SVGs with an explicit height/width were appearing offset and with wrong dimensions when added to the canvas
* Added method to create a height/width value for the SVG based on the SVGs viewBox

Fixes #185

## 🔍 Type of change

- [x] New feature

## ✅ Checklist

- [x] Code follows project coding standards
- [x] All TypeScript types are properly defined
- [x] Components are properly documented
- [x] No console.logs in production code
- [x] Responsive design tested on all breakpoints
- [x] No ESLint errors or warnings
- [x] No security audit errors or warnings
- [x] Lighthouse performance is still ok

## 💡 Additional context