### PR TITLE
Show 'Ladda Upp Egen Bild' button when src is missing or empty

### DIFF
--- a/components/features/BackgroundSelector.vue
+++ b/components/features/BackgroundSelector.vue
@@ -2,7 +2,7 @@
 
 <script setup lang="ts">
 // 1. Imports
-import { computed, onMounted, ref } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useCanvasStore } from '@/stores/canvasStore'
 import { CUSTOM_BACKGROUND_ID } from '~/composables/useCustomBackground'
@@ -19,9 +19,9 @@ const PRODUCT_CATEGORIES = PRODUCT_CATEGORIES_OBJ.productCategories
 
 // 3. Composables & Stores
 const canvasStore = useCanvasStore()
-const { activeCategory, activeProduct, activeSide, sides } = storeToRefs(canvasStore)
+const { activeCategory, activeProduct, activeSide } = storeToRefs(canvasStore)
 
-const { initProductCategories, onCategoryChange, onProductChange, onSideChange } = useBackgroundSelector()
+const { initBackgroundSelector, onCategoryChange, onProductChange, onSideChange } = useBackgroundSelector()
 
 // 4. State
 const customFileInputRef = ref<HTMLInputElement | null>(null)
@@ -94,9 +94,17 @@ async function handleCustomFileSelected(event: Event): Promise<void> {
 }
 
 // 7. Lifecycle hooks
-onMounted(() => {
-  initProductCategories()
-})
+
+// 8. Watchers
+// Watch for canvasStore.initialized and call initBackgroundSelector when it changes from false to true
+watch(
+  () => canvasStore.initialized,
+  (newVal, oldVal) => {
+    if (newVal && !oldVal) {
+      initBackgroundSelector()
+    }
+  }
+)
 </script>
 
 <template>

--- a/components/features/BackgroundSelector.vue
+++ b/components/features/BackgroundSelector.vue
@@ -29,7 +29,7 @@ const fileErrorMessage = ref('')
 
 // 5. Computed
 const isCustomSelected = computed(() =>
-  sides.value[activeSide.value]?.backgroundSelection === CUSTOM_BACKGROUND_ID,
+  !PRODUCT_CATEGORIES[activeCategory.value]?.products[activeProduct.value]?.sides[activeSide.value]?.src
 )
 
 const categoryOptions = computed<DropdownOption[]>(() =>

--- a/components/features/CanvasPanel.vue
+++ b/components/features/CanvasPanel.vue
@@ -71,7 +71,6 @@ async function initializeCanvas(side: number, el: HTMLCanvasElement, width: numb
 
   canvasInstance.on('object:added', () => canvasStore.save(side, canvasInstance, currentCanvasWidth))
   canvasInstance.on('object:modified', () => canvasStore.save(side, canvasInstance, currentCanvasWidth))
-  canvasInstance.on('object:removed', () => canvasStore.save(side, canvasInstance, currentCanvasWidth))
 
   // Set initialized state in store if all canvases are initialized
   const allInitialized = canvasStore.sideKeys.every(key => canvasMap.value[key])

--- a/components/features/CanvasPanel.vue
+++ b/components/features/CanvasPanel.vue
@@ -12,7 +12,6 @@ import { useCustomText } from '~/composables/useCustomText'
 import {
   clearCanvasObjects,
   clearCanvas,
-  getInitialBackgroundUrl,
   rescaleCanvas,
 } from '~/utils/canvasUtils'
 
@@ -70,28 +69,15 @@ async function initializeCanvas(side: number, el: HTMLCanvasElement, width: numb
 
   await canvasStore.restore(side, canvasInstance, width)
 
-  if (!canvasInstance.backgroundImage) {
-    const sideState = canvasStore.sides[side]
-    if (sideState?.backgroundSelection === CUSTOM_BACKGROUND_ID) {
-      // Restore a previously uploaded custom image; otherwise leave the canvas blank.
-      if (sideState.customBackgroundDataUrl) {
-        await applyBackgroundSelection(side, canvasInstance, CUSTOM_BACKGROUND_ID, false)
-      }
-    }
-    else {
-      const initialBackgroundUrl = getInitialBackgroundUrl(canvasStore.sides, side)
-      if (initialBackgroundUrl) {
-        await applyBackgroundSelection(side, canvasInstance, initialBackgroundUrl, false)
-        if (!sideState?.backgroundSelection) {
-          canvasStore.setBackgroundSelection(side, initialBackgroundUrl)
-        }
-      }
-    }
-  }
-
   canvasInstance.on('object:added', () => canvasStore.save(side, canvasInstance, currentCanvasWidth))
   canvasInstance.on('object:modified', () => canvasStore.save(side, canvasInstance, currentCanvasWidth))
   canvasInstance.on('object:removed', () => canvasStore.save(side, canvasInstance, currentCanvasWidth))
+
+  // Set initialized state in store if all canvases are initialized
+  const allInitialized = canvasStore.sideKeys.every(key => canvasMap.value[key])
+  if (allInitialized) {
+    canvasStore.setInitialized(true)
+  }
 }
 
 /** Assign or remove a canvas element ref from the template v-for */

--- a/components/features/CanvasPanel.vue
+++ b/components/features/CanvasPanel.vue
@@ -212,6 +212,7 @@ watch(
   () => canvasStore.sides.map(v => v.backgroundSelection),
   async (newSelections, oldSelections) => {
     for (let key = 0; key < newSelections.length; key++) {
+      let clearObjects = false
       const selection = newSelections[key]
       if (selection === oldSelections?.[key]) continue
       const canvas = canvasMap.value[key]
@@ -219,11 +220,10 @@ watch(
 
       if (!selection) {
         // Selection was explicitly cleared — wipe objects and background from the live canvas
-        clearCanvas(canvas, true)
-        continue
+        clearObjects = true
       }
 
-      await applyBackgroundSelection(key, canvas, selection)
+      await applyBackgroundSelection(key, canvas, selection, clearObjects)
     }
   },
   { deep: true },

--- a/components/features/CanvasPanel.vue
+++ b/components/features/CanvasPanel.vue
@@ -212,18 +212,12 @@ watch(
   () => canvasStore.sides.map(v => v.backgroundSelection),
   async (newSelections, oldSelections) => {
     for (let key = 0; key < newSelections.length; key++) {
-      let clearObjects = false
       const selection = newSelections[key]
       if (selection === oldSelections?.[key]) continue
       const canvas = canvasMap.value[key]
       if (!canvas) continue
 
-      if (!selection) {
-        // Selection was explicitly cleared — wipe objects and background from the live canvas
-        clearObjects = true
-      }
-
-      await applyBackgroundSelection(key, canvas, selection, clearObjects)
+      await applyBackgroundSelection(key, canvas, selection, true)
     }
   },
   { deep: true },

--- a/components/features/QuoteForm.vue
+++ b/components/features/QuoteForm.vue
@@ -75,7 +75,6 @@ function attachCanvasListeners(canvas: Canvas): void {
   if (!canvasesWithListeners.has(canvas)) {
     canvas.on('object:added', onCanvasChange)
     canvas.on('object:modified', onCanvasChange);
-    canvas.on('object:removed', onCanvasChange)
     canvasesWithListeners.add(canvas)
   }
 }
@@ -87,7 +86,6 @@ function detachCanvasListeners(canvas: Canvas): void {
   if (canvasesWithListeners.has(canvas)) {
     canvas.off('object:added', onCanvasChange)
     canvas.off('object:modified', onCanvasChange);
-    canvas.off('object:removed', onCanvasChange)
     canvasesWithListeners.delete(canvas)
   }
 }

--- a/components/features/QuoteForm.vue
+++ b/components/features/QuoteForm.vue
@@ -143,8 +143,8 @@ async function collectQuoteFiles(): Promise<File[]> {
     try {
       const canvasInstance = entry.canvas as Canvas
 
-      // Validate canvas is still valid before exporting
-      if (!canvasInstance) {
+      // Validate canvas is still valid and has a valid HTML element before exporting
+      if (!canvasInstance || !canvasInstance.elements.lower) {
         console.warn('collectQuoteFiles: canvas instance is no longer valid, skipping')
         continue
       }

--- a/composables/useBackgroundSelector.ts
+++ b/composables/useBackgroundSelector.ts
@@ -46,6 +46,7 @@ export function useBackgroundSelector() {
   function onProductChange(index: number, dataKey: string | null): void {
     canvasStore.setActiveProduct(index)
     canvasStore.setActiveSide(0)
+    canvasStore.clear()
     if (dataKey === CUSTOM_BACKGROUND_ID) {
       canvasStore.sides.forEach((_, i) => canvasStore.setBackgroundSelection(i, CUSTOM_BACKGROUND_ID))
     }

--- a/composables/useBackgroundSelector.ts
+++ b/composables/useBackgroundSelector.ts
@@ -2,12 +2,11 @@
 
 // 1. Imports
 import { useCanvasStore } from '@/stores/canvasStore'
-import { CUSTOM_BACKGROUND_ID, CUSTOM_SIDES } from '~/composables/useCustomBackground'
+import { CUSTOM_BACKGROUND_ID } from '~/composables/useCustomBackground'
 import rawBackgroundOptions from '~/assets/json/custom-design/products.json'
 import type { ProductCategories } from '~/types/BackgroundSelector'
 
 const PRODUCT_CATEGORIES_OBJ = rawBackgroundOptions as ProductCategories
-const PRODUCT_CATEGORIES = PRODUCT_CATEGORIES_OBJ.productCategories
 
 /**
  * Composable responsible for all product/category/side selection orchestration.
@@ -22,31 +21,11 @@ export function useBackgroundSelector() {
   // 3. Methods
 
   /** Registers the product category tree in the store once on mount and syncs the default product. */
-  function initProductCategories(): void {
+  function initBackgroundSelector(): void {
     canvasStore.setProductCategoryTree(PRODUCT_CATEGORIES_OBJ)
-    // Sync the default product's sides so sideCount matches what the side dropdown shows.
-    // Without this, sideCount stays at 2 while sideOptions shows all 4 sides, causing
-    // left/right canvases to never render on first load.
-    if (!canvasStore.sides.some(s => s.backgroundSelection)) {
-      const url = PRODUCT_CATEGORIES[canvasStore.activeCategory]?.products[canvasStore.activeProduct]?.sides[0]?.src
-      if (url) syncProductSelection(url)
-    }
-  }
-
-  /** Syncs store backgroundSelection for every side of the product that owns the given URL. */
-  function syncProductSelection(url: string): void {
-    for (const cat of PRODUCT_CATEGORIES) {
-      for (const product of cat.products) {
-        if (product.sides.some(s => s.src === url)) {
-          canvasStore.setSideCount(product.sides.length)
-          product.sides.forEach((side, i) => {
-            canvasStore.setBackgroundSelection(i, side.src)
-            canvasStore.setCustomBackgroundDataUrl(i, null)
-          })
-          return
-        }
-      }
-    }
+    canvasStore.setActiveCategory(0)
+    canvasStore.setActiveProduct(0)
+    canvasStore.setActiveSide(0)
   }
 
   /**
@@ -58,8 +37,6 @@ export function useBackgroundSelector() {
     canvasStore.setActiveProduct(0)
     canvasStore.setActiveSide(0)
     canvasStore.clear()
-    const url = PRODUCT_CATEGORIES[index]?.products[0]?.sides[0]?.src
-    if (url) syncProductSelection(url)
   }
 
   /**
@@ -70,13 +47,7 @@ export function useBackgroundSelector() {
     canvasStore.setActiveProduct(index)
     canvasStore.setActiveSide(0)
     if (dataKey === CUSTOM_BACKGROUND_ID) {
-      canvasStore.setSideCount(CUSTOM_SIDES.length)
-      CUSTOM_SIDES.forEach((_, i) => canvasStore.setBackgroundSelection(i, CUSTOM_BACKGROUND_ID))
-    }
-    else {
-      canvasStore.clear()
-      const url = PRODUCT_CATEGORIES[canvasStore.activeCategory]?.products[index]?.sides[0]?.src
-      if (url) syncProductSelection(url)
+      canvasStore.sides.forEach((_, i) => canvasStore.setBackgroundSelection(i, CUSTOM_BACKGROUND_ID))
     }
   }
 
@@ -86,7 +57,7 @@ export function useBackgroundSelector() {
   }
 
   return {
-    initProductCategories,
+    initBackgroundSelector,
     onCategoryChange,
     onProductChange,
     onSideChange,

--- a/composables/useCustomBackground.ts
+++ b/composables/useCustomBackground.ts
@@ -7,15 +7,6 @@ import { useCanvasStore } from '@/stores/canvasStore'
 
 export const CUSTOM_BACKGROUND_ID = 'custom'
 
-export const CUSTOM_SIDES: { label: string }[] = [
-  { label: 'Fram' },
-  { label: 'Bak' },
-  { label: 'Vänster' },
-  { label: 'Höger' },
-  { label: 'Över' },
-  { label: 'Under' },
-]
-
 /**
  * Loads a background image onto a canvas instance by URL.
  * Returns the loaded FabricImage so callers can read its dimensions (e.g. to update aspect ratio).

--- a/stores/canvasStore.ts
+++ b/stores/canvasStore.ts
@@ -4,6 +4,8 @@ import { defineStore } from 'pinia'
 import type { Canvas } from 'fabric'
 import type { ProductCategories } from '~/types/BackgroundSelector'
 
+const DEFAULT_SIDE_COUNT = 4
+
 /**
  * Canvas Store
  * @description Manages the state of N canvas sides dynamically. Sides are
@@ -31,13 +33,18 @@ const createSideState = (): CanvasSideState => ({
   customBackgroundDataUrl: null,
 })
 
-/** Creates initial sides state for the default two sides */
-function createInitialSides(): CanvasSideState[] {
-  return [createSideState(), createSideState()]
+/**
+ * Helper to create an array of CanvasSideState for the given count.
+ * Used for initializing and resetting the sides state.
+ */
+function createSides(count: number): CanvasSideState[] {
+  return Array.from({ length: count }, () => createSideState())
 }
 
 export const useCanvasStore = defineStore('canvas', {
   state: () => ({
+    /** True when all canvases are initialized */
+    initialized: false as boolean,
     /** Array of canvas instances indexed by side number */
     canvasMap: [] as (Canvas | undefined)[],
     /** The currently active product category name */
@@ -49,9 +56,9 @@ export const useCanvasStore = defineStore('canvas', {
     /** The currently active side index */
     activeSide: 0 as number ,
     /** State indexed by side number (0, 1, 2, …) */
-    sides: createInitialSides(),
+    sides: createSides(DEFAULT_SIDE_COUNT) as CanvasSideState[],
     /** Number of active sides for the selected product */
-    sideCount: 2 as number,
+    sideCount: DEFAULT_SIDE_COUNT as number,
     /** CSS aspect-ratio string for the active product's background image */
     aspectRatio: '1 / 1' as string,
     /** Incremented each time clear() is called; watchers use this to remove live canvas objects */
@@ -62,14 +69,20 @@ export const useCanvasStore = defineStore('canvas', {
     sideKeys: (state): number[] => Array.from({ length: state.sideCount }, (_, i) => i),
   },
   actions: {
-    /** Lazily initialize state for a side index if it doesn't exist yet */
-    ensureSide(side: number) {
-      while (this.sides.length <= side) {
-        this.sides.push(createSideState())
-      }
+    /** Helper to initialize sides, sideCount, backgrounds and customBackgroundDataUrl for all sides */
+    initSides() {
+      const sidesData = this.productCategoryTree?.productCategories[this.activeCategory]?.products[this.activeProduct]?.sides || [];
+      this.sideCount = sidesData.length || DEFAULT_SIDE_COUNT;
+      this.sides = createSides(this.sideCount);
+      this.sides.forEach((side, i) => {
+        side.backgroundSelection = sidesData[i]?.src || null; // Sync background selection from product data or set to null
+        side.customBackgroundDataUrl = null;
+      });
+    },
+    setInitialized(val: boolean) {
+      this.initialized = val
     },
     save(side: number, canvas: Canvas, size: number) {
-      this.ensureSide(side)
       const sideState = this.sides[side]!
       sideState.json = JSON.stringify(canvas.toJSON())
       sideState.size = size
@@ -102,11 +115,9 @@ export const useCanvasStore = defineStore('canvas', {
       this.canvasMap = map
     },
     setBackgroundSelection(side: number, selection: string | null) {
-      this.ensureSide(side)
       this.sides[side]!.backgroundSelection = selection
     },
     setCustomBackgroundDataUrl(side: number, dataUrl: string | null) {
-      this.ensureSide(side)
       this.sides[side]!.customBackgroundDataUrl = dataUrl
     },
     setProductCategoryTree(categories: ProductCategories | undefined) {
@@ -114,22 +125,14 @@ export const useCanvasStore = defineStore('canvas', {
     },
     setActiveCategory(category: number) {
       this.activeCategory = category
+      this.initSides()
     },
     setActiveProduct(product: number) {
       this.activeProduct = product
+      this.initSides()
     },
     setActiveSide(side: number) {
       this.activeSide = side
-    },
-    /**
-     * Set the number of active sides for the selected product.
-     * Ensures state objects exist for all indices.
-     */
-    setSideCount(count: number) {
-      this.sideCount = count
-      for (let i = 0; i < count; i++) {
-        this.ensureSide(i)
-      }
     },
     /** Clear user-added objects from all sides, preserving background selections */
     clear() {

--- a/stores/canvasStore.ts
+++ b/stores/canvasStore.ts
@@ -71,11 +71,11 @@ export const useCanvasStore = defineStore('canvas', {
   actions: {
     /** Helper to initialize sides, sideCount, backgrounds and customBackgroundDataUrl for all sides */
     initSides() {
-      const sidesData = this.productCategoryTree?.productCategories[this.activeCategory]?.products[this.activeProduct]?.sides || [];
-      this.sideCount = sidesData.length || DEFAULT_SIDE_COUNT;
+      const sidesArr = this.productCategoryTree?.productCategories[this.activeCategory]?.products[this.activeProduct]?.sides || [];
+      this.sideCount = sidesArr.length || DEFAULT_SIDE_COUNT;
       this.sides = createSides(this.sideCount);
       this.sides.forEach((side, i) => {
-        side.backgroundSelection = sidesData[i]?.src || null; // Sync background selection from product data or set to null
+        side.backgroundSelection = sidesArr[i]?.src || null; // Sync background selection from product data or set to null
         side.customBackgroundDataUrl = null;
       });
     },

--- a/utils/canvasUtils.ts
+++ b/utils/canvasUtils.ts
@@ -6,7 +6,6 @@
 import type { FabricObject, Canvas, FabricImage } from 'fabric'
 import type { CircularTextbox } from './circularTextbox'
 import { Path, Point } from 'fabric'
-import { CUSTOM_BACKGROUND_ID } from '~/composables/useCustomBackground'
 
 // Valid range for text radius to create a circular path
 export const MIN_TEXT_RADIUS = 25
@@ -132,28 +131,6 @@ export function setTextboxTextRadius(textbox: CircularTextbox, radius: number): 
   textbox.controls.resize.visible = !nextHasPath
   textbox.setPositionByOrigin(center, 'center', 'center')
   textbox.setCoords()
-}
-
-/**
- * Returns the initial background URL for a given canvas side.
- * Uses the stored selection if present, otherwise falls back to hardcoded defaults
- * for the first two sides.
- */
-export function getInitialBackgroundUrl(
-  sides: Array<{ backgroundSelection: string | null } | undefined>,
-  sideKey: number,
-): string {
-  const state = sides[sideKey]
-  if (state?.backgroundSelection && state.backgroundSelection !== CUSTOM_BACKGROUND_ID) {
-    return state.backgroundSelection
-  }
-  const defaults: string[] = [
-    '/images/custom-design/t-shirt-front.jpg',
-    '/images/custom-design/t-shirt-back.jpg',
-    '/images/custom-design/t-shirt-left.jpg',
-    '/images/custom-design/t-shirt-right.jpg'
-  ]
-  return defaults[sideKey] ?? ''
 }
 
 export function clearCanvasObjects(canvas: Canvas): void {


### PR DESCRIPTION
## 📝 Description

- Show 'Ladda Upp Egen Bild' button when src is missing or empty.
- Fixed: When selecting 'Under' without explicitly selecting 'Egen produkt' the Canvas dissapears.

Fixes #194

## 🔍 Type of change

- [x] Bug fix

## ✅ Checklist

- [x] Code follows project coding standards
- [x] All TypeScript types are properly defined
- [x] Components are properly documented
- [x] No console.logs in production code
- [x] Responsive design tested on all breakpoints
- [x] No ESLint errors or warnings
- [x] No security audit errors or warnings
- [x] Lighthouse performance is still ok

## 💡 Additional context
