### PR TITLE
202-add-information-about-fonts-text-used-in-quoteform

### DIFF
--- a/components/features/QuoteForm.vue
+++ b/components/features/QuoteForm.vue
@@ -311,7 +311,11 @@ function openGdprDialog(): void {
 async function handleSubmit(): Promise<void> {
   // Delay validation TAP_ANIMATION_TIME ms to allow tap animation to complete
   await new Promise(resolve => setTimeout(resolve, TAP_ANIMATION_TIME))
-  
+
+  // Re-collect texts fresh at submit time so programmatic changes via the
+  // controls panel (which fire no canvas events) are always included
+  formData.value.canvasTexts = collectCanvasTexts()
+
   const success = await submitForm()
 
   if (success) {

--- a/components/features/QuoteForm.vue
+++ b/components/features/QuoteForm.vue
@@ -101,6 +101,22 @@ function cleanFontFamily(fontFamily: string): string {
   return primary.replace(/['"/]/g, '')
 }
 
+function normalizeFontWeight(fontWeight: number | string): number {
+  if (typeof fontWeight === 'number') {
+    return fontWeight >= 600 ? 700 : 400
+  }
+
+  if (fontWeight === 'bold') return 700
+  if (fontWeight === 'normal') return 400
+
+  const parsed = Number.parseInt(fontWeight, 10)
+  if (Number.isFinite(parsed)) {
+    return parsed >= 600 ? 700 : 400
+  }
+
+  return 400
+}
+
 /**
  * Collect text objects from all active canvases and return a human-readable string.
  * Each entry describes the side label and the text properties on that side.
@@ -123,7 +139,7 @@ function collectCanvasTexts(): string {
       texts: textObjects.map(obj => ({
         text: obj.text ?? '',
         fontFamily: cleanFontFamily(obj.fontFamily ?? ''),
-        fontWeight: obj.fontWeight ?? 400,
+        fontWeight: normalizeFontWeight(obj.fontWeight ?? 400),
         isItalic: obj.fontStyle === 'italic',
         color: (obj.fill as string) ?? '#000000',
       })),

--- a/components/features/QuoteForm.vue
+++ b/components/features/QuoteForm.vue
@@ -5,6 +5,7 @@
 import { computed, defineAsyncComponent, ref, watch } from 'vue'
 import { nanoid } from 'nanoid'
 import type { Canvas } from 'fabric'
+import { Textbox } from 'fabric'
 import type { QuoteFormData } from '~/composables/useQuoteForm'
 import { useQuoteForm, MAX_IMAGE_COUNT } from '~/composables/useQuoteForm'
 import TextButton from '~/components/common/TextButton.vue'
@@ -12,6 +13,7 @@ import { storeToRefs } from 'pinia'
 import { useCanvasStore } from '@/stores/canvasStore'
 import { useCanvasExport } from '~/composables/useCanvasExport'
 import { TAP_ANIMATION_TIME } from '~/constants/ui'
+import type { SideTextInfo } from '~/types/CanvasText'
 
 // ===== ASYNC COMPONENTS =====
 const GdprDialog = defineAsyncComponent(() =>
@@ -88,6 +90,49 @@ function detachCanvasListeners(canvas: Canvas): void {
     canvas.off('object:modified', onCanvasChange);
     canvasesWithListeners.delete(canvas)
   }
+}
+
+/**
+ * Clean a CSS font-family string to just the primary font name.
+ * E.g. "'Inter', sans-serif" → "Inter"
+ */
+function cleanFontFamily(fontFamily: string): string {
+  const primary = fontFamily.split(',')[0].trim()
+  return primary.replace(/['"/]/g, '')
+}
+
+/**
+ * Collect text objects from all active canvases and return a JSON string.
+ * Each entry describes the side label and an array of text object properties.
+ */
+function collectCanvasTexts(): string {
+  const result: SideTextInfo[] = []
+
+  canvasMap.value.forEach((canvas, index) => {
+    if (!canvas) return
+
+    const textObjects = canvas.getObjects().filter(
+      (obj): obj is Textbox => obj instanceof Textbox
+    )
+
+    if (textObjects.length === 0) return
+
+    const sideLabel = activeSideLabels.value[index]?.label ?? `Sida ${index + 1}`
+    result.push({
+      side: sideLabel,
+      texts: textObjects.map(obj => ({
+        text: obj.text ?? '',
+        fontFamily: cleanFontFamily(obj.fontFamily ?? ''),
+        fontSize: Math.round(obj.fontSize ?? 0),
+        fontWeight: obj.fontWeight ?? 400,
+        color: (obj.fill as string) ?? '#000000',
+        textAlign: obj.textAlign ?? 'left',
+        textRadius: (obj as Textbox & { textRadius?: number }).textRadius ?? 0,
+      })),
+    })
+  })
+
+  return result.length > 0 ? JSON.stringify(result) : ''
 }
 
 /**
@@ -183,6 +228,8 @@ async function collectCanvasImages(): Promise<void> {
     isCollectingImages.value = true
     // Collect current canvas images and populate formData before user submits
     formData.value.images = await collectQuoteFiles()
+    // Collect text objects from all canvases
+    formData.value.canvasTexts = collectCanvasTexts()
     // Sync each image to its corresponding hidden file input for Netlify submission
     formData.value.images?.forEach((file, index) => {
       const ref = fileInputRefs.value[index]
@@ -363,6 +410,7 @@ watch(canvasMap, async (newCanvases) => {
 
     <!-- Hidden fields for Netlify -->
     <input type="hidden" name="form-name" value="quote">
+    <input type="hidden" name="canvas_texts" :value="formData.canvasTexts">
     <p class="sr-only">
       <label>
         Don't fill this out if you're human:

--- a/components/features/QuoteForm.vue
+++ b/components/features/QuoteForm.vue
@@ -102,8 +102,8 @@ function cleanFontFamily(fontFamily: string): string {
 }
 
 /**
- * Collect text objects from all active canvases and return a JSON string.
- * Each entry describes the side label and an array of text object properties.
+ * Collect text objects from all active canvases and return a human-readable string.
+ * Each entry describes the side label and the text properties on that side.
  */
 function collectCanvasTexts(): string {
   const result: SideTextInfo[] = []
@@ -123,16 +123,22 @@ function collectCanvasTexts(): string {
       texts: textObjects.map(obj => ({
         text: obj.text ?? '',
         fontFamily: cleanFontFamily(obj.fontFamily ?? ''),
-        fontSize: Math.round(obj.fontSize ?? 0),
         fontWeight: obj.fontWeight ?? 400,
         color: (obj.fill as string) ?? '#000000',
-        textAlign: obj.textAlign ?? 'left',
-        textRadius: (obj as Textbox & { textRadius?: number }).textRadius ?? 0,
       })),
     })
   })
 
-  return result.length > 0 ? JSON.stringify(result) : ''
+  if (result.length === 0) return ''
+
+  return result
+    .map(side => [
+      `[ ${side.side} ]`,
+      ...side.texts.map((t, i) =>
+        `Text ${i + 1}: "${t.text}" | Typsnitt: ${t.fontFamily} ${t.fontWeight} | Färg: ${t.color}`
+      ),
+    ].join('\n'))
+    .join('\n\n')
 }
 
 /**

--- a/components/features/QuoteForm.vue
+++ b/components/features/QuoteForm.vue
@@ -31,7 +31,7 @@ const emit = defineEmits<{
 
 // ===== COMPOSABLES & STORES =====
 const canvasStore = useCanvasStore()
-const { canvasMap, productCategoryTree, activeCategory, activeProduct } = storeToRefs(canvasStore)
+const { canvasMap, productCategoryTree, activeCategory, activeProduct, textControlsSeq } = storeToRefs(canvasStore)
 const { exportMergedImage, exportImageObjects } = useCanvasExport()
 const {
   formData,
@@ -124,6 +124,7 @@ function collectCanvasTexts(): string {
         text: obj.text ?? '',
         fontFamily: cleanFontFamily(obj.fontFamily ?? ''),
         fontWeight: obj.fontWeight ?? 400,
+        isItalic: obj.fontStyle === 'italic',
         color: (obj.fill as string) ?? '#000000',
       })),
     })
@@ -135,7 +136,7 @@ function collectCanvasTexts(): string {
     .map(side => [
       `[ ${side.side} ]`,
       ...side.texts.map((t, i) =>
-        `Text ${i + 1}: "${t.text}" | Typsnitt: ${t.fontFamily} ${t.fontWeight} | Färg: ${t.color}`
+        `Text ${i + 1}: "${t.text}" | Typsnitt: ${t.fontFamily} ${t.fontWeight}${t.isItalic ? ' italic' : ''} | Färg: ${t.color}`
       ),
     ].join('\n'))
     .join('\n\n')
@@ -363,6 +364,14 @@ watch(activeProductLabel, (label) => {
  */
 watch(isChanged, (newValue) => {
   emit('changed', newValue)
+})
+
+/**
+ * Re-collect canvas texts when TextboxControls programmatically changes a textbox
+ * property (font, bold, italic, color, etc.) — these don't fire canvas events.
+ */
+watch(textControlsSeq, () => {
+  formData.value.canvasTexts = collectCanvasTexts()
 })
 
 /**
@@ -1002,6 +1011,25 @@ watch(canvasMap, async (newCanvases) => {
         </ul>
       </div>
 
+      <!-- Display canvas texts to user -->
+      <input type="hidden" name="texter" :value="formData.canvasTexts">
+      <div v-if="formData.canvasTexts" aria-live="polite">
+        <p class="block text-sm sm:text-base font-medium text-neutral-900 mb-1.5">
+          Tillagda texter
+        </p>
+        <ul
+          class="w-full px-4 py-2.5 text-sm border border-neutral-300 rounded-input bg-neutral-100 text-neutral-600 space-y-1 list-none cursor-not-allowed"
+          aria-label="Texter som biläggs formuläret"
+        >
+          <li
+            v-for="line in formData.canvasTexts.split('\n')"
+            :key="line"
+          >
+            {{ line }}
+          </li>
+        </ul>
+      </div>
+
       <!-- ── Message (optional) ─────────────────────────────── -->
       <div>
         <label
@@ -1034,7 +1062,6 @@ watch(canvasMap, async (newCanvases) => {
           {{ getFieldError('message') }}
         </p>
       </div>
-      <input type="hidden" name="texter" :value="formData.canvasTexts">
 
       <!-- ── GDPR consent ───────────────────────────────────── -->
       <div>

--- a/components/features/QuoteForm.vue
+++ b/components/features/QuoteForm.vue
@@ -416,7 +416,6 @@ watch(canvasMap, async (newCanvases) => {
 
     <!-- Hidden fields for Netlify -->
     <input type="hidden" name="form-name" value="quote">
-    <input type="hidden" name="canvas_texts" :value="formData.canvasTexts">
     <p class="sr-only">
       <label>
         Don't fill this out if you're human:
@@ -1031,6 +1030,7 @@ watch(canvasMap, async (newCanvases) => {
           {{ getFieldError('message') }}
         </p>
       </div>
+      <input type="hidden" name="canvas_texts" :value="formData.canvasTexts">
 
       <!-- ── GDPR consent ───────────────────────────────────── -->
       <div>

--- a/components/features/QuoteForm.vue
+++ b/components/features/QuoteForm.vue
@@ -1030,7 +1030,7 @@ watch(canvasMap, async (newCanvases) => {
           {{ getFieldError('message') }}
         </p>
       </div>
-      <input type="hidden" name="canvas_texts" :value="formData.canvasTexts">
+      <input type="hidden" name="texter" :value="formData.canvasTexts">
 
       <!-- ── GDPR consent ───────────────────────────────────── -->
       <div>

--- a/components/features/TextboxControls.vue
+++ b/components/features/TextboxControls.vue
@@ -204,7 +204,7 @@ async function updateFontFamily() {
 
 function toggleBold() {
   isBold.value = !isBold.value
-  applyToAll(tb => tb.set('fontWeight', isBold.value ? 'bold' : 'normal'))
+  applyToAll(tb => tb.set('fontWeight', isBold.value ? 700 : 400))
 }
 
 function toggleItalic() {

--- a/components/features/TextboxControls.vue
+++ b/components/features/TextboxControls.vue
@@ -33,7 +33,6 @@ const selectedTextboxes = shallowRef<Textbox[]>([])
 const fontFamily = ref("'Inter', sans-serif")
 const isBold = ref(false)
 const isItalic = ref(false)
-const textAlign = ref<'left' | 'center' | 'right'>('left')
 const fill = ref('#000000')
 // warpSlider: -100 to 100, where 0 = no warp, ±100 = maximum warp.
 // Positive = text curves upward (left side of arc), negative = downward (right side).
@@ -164,7 +163,6 @@ function syncFromFirst() {
   ensureFontLoaded(fontFamily.value) // Fire and forget
   isBold.value = first.fontWeight === 'bold' || first.fontWeight === 700
   isItalic.value = first.fontStyle === 'italic'
-  textAlign.value = (first.textAlign as 'left' | 'center' | 'right') ?? 'left'
   fill.value = (first.fill as string) ?? '#000000'
   textValue.value = first.text ?? ''
   warpSlider.value = first instanceof CircularTextbox ? radiusToSlider(first.textRadius) : 0
@@ -210,13 +208,6 @@ function toggleBold() {
 function toggleItalic() {
   isItalic.value = !isItalic.value
   applyToAll(tb => tb.set('fontStyle', isItalic.value ? 'italic' : 'normal'))
-}
-
-function cycleAlignment() {
-  const order: Array<'left' | 'center' | 'right'> = ['left', 'center', 'right']
-  const next = order[(order.indexOf(textAlign.value) + 1) % order.length]
-  textAlign.value = next
-  applyToAll(tb => tb.set('textAlign', next))
 }
 
 function updateColor() {
@@ -354,34 +345,6 @@ watch(() => props.canvas, (newCanvas, oldCanvas) => {
           @click="toggleItalic"
         >
           I
-        </button>
-
-        <!-- Alignment Cycle -->
-        <button
-          type="button"
-          class="min-w-[44px] min-h-[44px] flex items-center justify-center px-3 py-2 border-gray-300 bg-gray-50 cursor-pointer hover:bg-gray-100 form-button-base outline-tight-button"
-          title="Text Alignment"
-          aria-label="Cycle text alignment"
-          @click="cycleAlignment"
-        >
-          <!-- Align Left -->
-          <svg v-if="textAlign === 'left'" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <line x1="3" y1="6" x2="21" y2="6" />
-            <line x1="3" y1="12" x2="15" y2="12" />
-            <line x1="3" y1="18" x2="18" y2="18" />
-          </svg>
-          <!-- Align Center -->
-          <svg v-else-if="textAlign === 'center'" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <line x1="3" y1="6" x2="21" y2="6" />
-            <line x1="6" y1="12" x2="18" y2="12" />
-            <line x1="4" y1="18" x2="20" y2="18" />
-          </svg>
-          <!-- Align Right -->
-          <svg v-else xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <line x1="3" y1="6" x2="21" y2="6" />
-            <line x1="9" y1="12" x2="21" y2="12" />
-            <line x1="6" y1="18" x2="21" y2="18" />
-          </svg>
         </button>
 
         <!-- Color -->

--- a/components/features/TextboxControls.vue
+++ b/components/features/TextboxControls.vue
@@ -177,6 +177,10 @@ function applyToAll(updater: (tb: Textbox) => void) {
     tb.setCoords()
   }
   props.canvas.requestRenderAll()
+  // Fire object:modified so external listeners (e.g. QuoteForm) pick up the change
+  for (const tb of selectedTextboxes.value) {
+    props.canvas.fire('object:modified', { target: tb })
+  }
 }
 
 /**

--- a/components/features/TextboxControls.vue
+++ b/components/features/TextboxControls.vue
@@ -177,10 +177,6 @@ function applyToAll(updater: (tb: Textbox) => void) {
     tb.setCoords()
   }
   props.canvas.requestRenderAll()
-  // Fire object:modified so external listeners (e.g. QuoteForm) pick up the change
-  for (const tb of selectedTextboxes.value) {
-    props.canvas.fire('object:modified', { target: tb })
-  }
 }
 
 /**

--- a/components/features/TextboxControls.vue
+++ b/components/features/TextboxControls.vue
@@ -8,6 +8,7 @@ import { setTextboxTextRadius, MIN_TEXT_RADIUS, MAX_TEXT_RADIUS } from '~/utils/
 import { CircularTextbox } from '~/utils/circularTextbox'
 import BaseDropdown from '~/components/base/BaseDropdown.vue'
 import type { DropdownGroup } from '~/components/base/BaseDropdown.vue'
+import { useCanvasStore } from '@/stores/canvasStore'
 
 // Font names used for eager preloading on mount
 const FONT_NAMES = [
@@ -25,7 +26,7 @@ interface Props {
 const props = defineProps<Props>()
 
 // 3. Composables & Stores
-// (none)
+const canvasStore = useCanvasStore()
 
 // 4. State (ref/reactive)
 const selectedTextboxes = shallowRef<Textbox[]>([])
@@ -177,6 +178,7 @@ function applyToAll(updater: (tb: Textbox) => void) {
     tb.setCoords()
   }
   props.canvas.requestRenderAll()
+  canvasStore.notifyTextControlsChanged()
 }
 
 /**

--- a/composables/useQuoteForm.ts
+++ b/composables/useQuoteForm.ts
@@ -283,7 +283,7 @@ export function useQuoteForm() {
       }
       formDataToSubmit.append('gdpr_consent', formData.value.gdprConsent.toString())
       if (formData.value.canvasTexts) {
-        formDataToSubmit.append('canvas_texts', formData.value.canvasTexts)
+        formDataToSubmit.append('texter', formData.value.canvasTexts)
       }
       formDataToSubmit.append('bot-field', '')
 

--- a/composables/useQuoteForm.ts
+++ b/composables/useQuoteForm.ts
@@ -278,13 +278,13 @@ export function useQuoteForm() {
       formData.value.images?.forEach((file, index) => {
         formDataToSubmit.append(`image_${index + 1}`, file)
       })
-      if (formData.value.canvasTexts) {
-        formDataToSubmit.append('canvas_texts', formData.value.canvasTexts)
-      }
       if (formData.value.message) {
         formDataToSubmit.append('message', formData.value.message)
       }
       formDataToSubmit.append('gdpr_consent', formData.value.gdprConsent.toString())
+      if (formData.value.canvasTexts) {
+        formDataToSubmit.append('canvas_texts', formData.value.canvasTexts)
+      }
       formDataToSubmit.append('bot-field', '')
 
       // Submit to Netlify Forms

--- a/composables/useQuoteForm.ts
+++ b/composables/useQuoteForm.ts
@@ -69,6 +69,7 @@ export const quoteFormSchema = z.object({
     .int('Antal måste vara ett heltal')
     .min(1, 'Antal måste vara minst 1')
     .max(10000, 'Antal får inte vara mer än 10 000'),
+  canvasTexts: z.string().optional(),
   images: z
     .array(z.custom<File>((file) => {
       if (!file) return true // Optional field
@@ -117,8 +118,8 @@ export function useQuoteForm() {
 
   // ===== STATE =====
   const formData = ref<QuoteFormData>({ ...quoteFormStore.formData })
-  const initialFormData = ref<Omit<QuoteFormData, 'images'>>(
-    (({ images: _i, ...rest }) => rest)(formData.value),
+  const initialFormData = ref<Omit<QuoteFormData, 'images' | 'canvasTexts'>>(
+    (({ images: _i, canvasTexts: _ct, ...rest }) => rest)(formData.value),
   )
   const formState = ref<FormState>('idle')
   const fieldErrors = ref<Map<keyof QuoteFormData, string>>(new Map())
@@ -130,7 +131,7 @@ export function useQuoteForm() {
    * Files are excluded because they are prop-injected and cannot be serialised.
    */
   const isChanged = computed(() => {
-    const editableData = (({ images: _i, ...rest }) => rest)(formData.value)
+    const editableData = (({ images: _i, canvasTexts: _ct, ...rest }) => rest)(formData.value)
     return JSON.stringify(editableData) !== JSON.stringify(initialFormData.value)
   })
 
@@ -231,9 +232,10 @@ export function useQuoteForm() {
     formData.value.productId = ''
     formData.value.size = ''
     formData.value.productCount = undefined as unknown as number
+    formData.value.canvasTexts = ''
     formData.value.message = ''
     formData.value.gdprConsent = false
-    initialFormData.value = (({ images: _i, ...rest }) => rest)(formData.value)
+    initialFormData.value = (({ images: _i, canvasTexts: _ct, ...rest }) => rest)(formData.value)
     clearErrors()
     formState.value = 'idle'
     quoteFormStore.resetForm()
@@ -276,6 +278,9 @@ export function useQuoteForm() {
       formData.value.images?.forEach((file, index) => {
         formDataToSubmit.append(`image_${index + 1}`, file)
       })
+      if (formData.value.canvasTexts) {
+        formDataToSubmit.append('canvas_texts', formData.value.canvasTexts)
+      }
       if (formData.value.message) {
         formDataToSubmit.append('message', formData.value.message)
       }

--- a/public/netlify-forms.html
+++ b/public/netlify-forms.html
@@ -64,6 +64,7 @@
       <input type="file" name="image_14" autocomplete="off">
       <input type="file" name="image_15" autocomplete="off">
       <input type="file" name="image_16" autocomplete="off">
+      <input type="hidden" name="canvas_texts">
       <textarea name="message" autocomplete="off"></textarea>
       <input type="checkbox" name="gdpr_consent" autocomplete="off">
       <input name="bot-field" autocomplete="off" style="display:none">

--- a/public/netlify-forms.html
+++ b/public/netlify-forms.html
@@ -64,7 +64,7 @@
       <input type="file" name="image_14" autocomplete="off">
       <input type="file" name="image_15" autocomplete="off">
       <input type="file" name="image_16" autocomplete="off">
-      <input type="hidden" name="canvas_texts">
+      <input type="hidden" name="texter">
       <textarea name="message" autocomplete="off"></textarea>
       <input type="checkbox" name="gdpr_consent" autocomplete="off">
       <input name="bot-field" autocomplete="off" style="display:none">

--- a/stores/canvasStore.ts
+++ b/stores/canvasStore.ts
@@ -65,6 +65,8 @@ export const useCanvasStore = defineStore('canvas', {
     clearSeq: 0 as number,
     /** Incremented each time clearObjects() is called; watchers use this to remove only user-added live canvas objects */
     clearObjectsSeq: 0 as number,
+    /** Incremented each time TextboxControls programmatically modifies a textbox property */
+    textControlsSeq: 0 as number,
   }),
   getters: {
     /** Ordered list of active side indices derived from sideCount */
@@ -154,6 +156,10 @@ export const useCanvasStore = defineStore('canvas', {
     },
     setAspectRatio(ratio: string) {
       this.aspectRatio = ratio
+    },
+    /** Notify watchers that TextboxControls programmatically changed a textbox property */
+    notifyTextControlsChanged() {
+      this.textControlsSeq++
     },
   },
 })

--- a/stores/quoteFormStore.ts
+++ b/stores/quoteFormStore.ts
@@ -21,6 +21,7 @@ export const useQuoteFormStore = defineStore('quoteForm', () => {
     size: '',
     productCount: undefined as unknown as number,
     images: [],
+    canvasTexts: '',
     message: '',
     gdprConsent: false,
   })
@@ -67,6 +68,7 @@ export const useQuoteFormStore = defineStore('quoteForm', () => {
       size: '',
       productCount: undefined as unknown as number,
       images: [],
+      canvasTexts: '',
       message: '',
       gdprConsent: false,
     }

--- a/types/CanvasText.ts
+++ b/types/CanvasText.ts
@@ -2,6 +2,7 @@ export interface TextEntry {
   text: string
   fontFamily: string
   fontWeight: number | string
+  isItalic: boolean
   color: string
 }
 

--- a/types/CanvasText.ts
+++ b/types/CanvasText.ts
@@ -1,0 +1,14 @@
+export interface TextEntry {
+  text: string
+  fontFamily: string
+  fontSize: number
+  fontWeight: number | string
+  color: string
+  textAlign: string
+  textRadius: number
+}
+
+export interface SideTextInfo {
+  side: string
+  texts: TextEntry[]
+}

--- a/types/CanvasText.ts
+++ b/types/CanvasText.ts
@@ -1,11 +1,8 @@
 export interface TextEntry {
   text: string
   fontFamily: string
-  fontSize: number
   fontWeight: number | string
   color: string
-  textAlign: string
-  textRadius: number
 }
 
 export interface SideTextInfo {


### PR DESCRIPTION
## 📝 Description

Added feature to export the text fields and properties for those fields into the netlify form

Fixes #202

## 🔍 Type of change

- [x] New feature

## ✅ Checklist

- [x] Code follows project coding standards
- [x] All TypeScript types are properly defined
- [x] Components are properly documented
- [x] No console.logs in production code
- [x] Responsive design tested on all breakpoints
- [x] No ESLint errors or warnings
- [x] No security audit errors or warnings
- [x] Lighthouse performance is still ok

## 💡 Additional context

Add any other context about the PR here.
