### PR TITLE
213 defer forms

### DIFF
--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -1338,9 +1338,9 @@ import { formatDate, calculateTotal } from '~/utils'
 ```vue
 <script setup lang="ts">
 // Lazy load heavy components
-const HeavyChart = defineAsyncComponent(() => import('~/components/HeavyChart.vue'))
+const HeavyChart = defineAsyncComponent(() => import('~/components/features/HeavyChart.vue'))
 
-const LazyModal = defineAsyncComponent(() => import('~/components/Modal.vue'))
+const LazyModal = defineAsyncComponent(() => import('~/components/base/Modal.vue'))
 </script>
 
 <template>

--- a/pages/contact.vue
+++ b/pages/contact.vue
@@ -7,6 +7,7 @@ import { useSiteUrl } from '~/composables/useSiteUrl'
 import HeroImage from '~/components/common/HeroImage.vue'
 import Section from '~/components/common/Section.vue'
 import ContactPanel from '~/components/features/ContactPanel.vue'
+
 // Lazy-load ContactForm so Zod is kept out of the shared synchronous bundle
 const ContactForm = defineAsyncComponent(() => import('~/components/features/ContactForm.vue'))
 


### PR DESCRIPTION
## 📝 Description

Deferred forms

Fixes #213

## 🔍 Type of change

- [x] New feature

## ✅ Checklist

- [x] Code follows project coding standards
- [x] All TypeScript types are properly defined
- [x] Components are properly documented
- [x] No console.logs in production code
- [x] Responsive design tested on all breakpoints
- [x] No ESLint errors or warnings
- [x] No security audit errors or warnings
- [x] Lighthouse performance is still ok

## 💡 Additional context

Defering the QuoteForm and ContactForm does not improve the LCP as both forms are already lazy-loaded and defering them even further (to window.load) has no impact on LCP since we can't render the forms conditionally (as we do with the DesignPanel). Note that we need ServerSideRendering of the forms for NetlifyForms to detect the form fields.