### PR TITLE
212-custom-design-canvas-objects-lose-focus-when-finishing-a-drag-and-drop

### DIFF
--- a/composables/useCanvasExport.ts
+++ b/composables/useCanvasExport.ts
@@ -97,10 +97,11 @@ function stampSvgExportSize(svgDataUrl: string, width: number, height: number, a
 
 export function useCanvasExport() {
   async function exportMergedImage(canvas: Canvas): Promise<string> {
-    canvas.discardActiveObject()
-    canvas.renderAll() // Ensure canvas is fully rendered before export
+    // Render to an offscreen canvas so the live canvas is never repainted without
+    // selection handles. toCanvasElement sets skipControlsDrawing=true internally,
+    // so the export never includes selection borders — no need to discardActiveObject.
+    const offscreenEl = canvas.toCanvasElement()
 
-    const htmlCanvas = canvas.getElement() as HTMLCanvasElement
     const bg = canvas.backgroundImage as FabricImage | undefined
 
     // When all canvases share a single wrapper div, switching sides forces every
@@ -115,14 +116,14 @@ export function useCanvasExport() {
       const renderedBgW = Math.round(bg.width * (canvasH / bg.height))
       if (renderedBgW < canvasW - 1) {
         const srcX = Math.round((canvasW - renderedBgW) / 2)
-        const offscreen = document.createElement('canvas')
-        offscreen.width = renderedBgW
-        offscreen.height = canvasH
-        const ctx = offscreen.getContext('2d')
+        const cropCanvas = document.createElement('canvas')
+        cropCanvas.width = renderedBgW
+        cropCanvas.height = canvasH
+        const ctx = cropCanvas.getContext('2d')
         if (ctx) {
-          ctx.drawImage(htmlCanvas, srcX, 0, renderedBgW, canvasH, 0, 0, renderedBgW, canvasH)
+          ctx.drawImage(offscreenEl, srcX, 0, renderedBgW, canvasH, 0, 0, renderedBgW, canvasH)
           return new Promise<string>((resolve, reject) => {
-            offscreen.toBlob((blob) => {
+            cropCanvas.toBlob((blob) => {
               if (!blob) return reject(new Error('toBlob returned null'))
               resolve(URL.createObjectURL(blob))
             }, 'image/png')
@@ -131,16 +132,16 @@ export function useCanvasExport() {
       }
     }
 
-    if (typeof htmlCanvas.toBlob === 'function') {
+    if (typeof offscreenEl.toBlob === 'function') {
       return new Promise((resolve, reject) => {
-        htmlCanvas.toBlob((blob) => {
+        offscreenEl.toBlob((blob) => {
           if (!blob) return reject(new Error('toBlob returned null'))
           resolve(URL.createObjectURL(blob))
         }, 'image/png')
       })
     }
 
-    return canvas.toDataURL({ format: 'png', multiplier: 1 })
+    return offscreenEl.toDataURL()
   }
 
   async function exportImageObjects(canvas: Canvas): Promise<ExportedLayer[]> {

--- a/composables/useCanvasExport.ts
+++ b/composables/useCanvasExport.ts
@@ -141,7 +141,7 @@ export function useCanvasExport() {
       })
     }
 
-    return offscreenEl.toDataURL()
+    return offscreenEl.toDataURL('image/png')
   }
 
   async function exportImageObjects(canvas: Canvas): Promise<ExportedLayer[]> {

--- a/composables/useCanvasText.ts
+++ b/composables/useCanvasText.ts
@@ -96,6 +96,8 @@ export function useCanvasText() {
         x: 0,
         y: -0.5,
         offsetY: -50,
+        sizeX: 36,
+        sizeY: 36,
         cursorStyle: 'grab',
         render: createRotateControlRender(getRotateImage()),
         withConnection: true,


### PR DESCRIPTION
## 📝 Description

* Changed how export merged image works to prevent objects from losing focus on each object:modified event
* Increased clickable area of rotate button. 

Fixes #212

## 🔍 Type of change

- [x] New feature

## ✅ Checklist

- [x] Code follows project coding standards
- [x] All TypeScript types are properly defined
- [x] Components are properly documented
- [x] No console.logs in production code
- [x] Responsive design tested on all breakpoints
- [x] No ESLint errors or warnings
- [x] No security audit errors or warnings
- [x] Lighthouse performance is still ok

## 💡 Additional context

Add any other context about the PR here.
