### PR TITLE
Fixed: The OG Image URL appears to be invalid or unreachable

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,7 +11,8 @@
   SITE_URL = ""
 
 [context.production.environment]
-  SITE_URL = "https://www.tricolorscreen.se"
+  # TODO: Change back to https://www.tricolorscreen.se once www.tricolorscreen.se is properly routed to Netlify
+  SITE_URL = "https://tricolorscreen.netlify.app"
 
 [[redirects]]
 from = "http://tricolorscreen.se/*"


### PR DESCRIPTION
## 📝 Description

Change production SITE_URL to `https://tricolorscreen.netlify.app/` temporary until we deploy.

Fixes #238 

## 🔍 Type of change

- [x] Bug fix

## ✅ Checklist

- [x] Code follows project coding standards
- [x] All TypeScript types are properly defined
- [x] Components are properly documented
- [x] No console.logs in production code
- [x] Responsive design tested on all breakpoints
- [x] No ESLint errors or warnings
- [x] No security audit errors or warnings
- [x] Lighthouse performance is still ok

## 💡 Additional context
Change back to `https://www.tricolorscreen.se` once `www.tricolorscreen.se` is properly routed to Netlify